### PR TITLE
Implements a checker to ban a list of packages and classes

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,0 +1,3 @@
+//dependencies {
+//    annotationProcessor project(":plugin")
+//}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,10 +1,11 @@
 dependencies {
-  compileOnly 'com.google.errorprone:error_prone_core:latest.release'
-  compileOnly 'com.google.errorprone:error_prone_annotation:latest.release'
-  testImplementation("com.google.errorprone:error_prone_test_helpers:latest.release")
+    compileOnly 'com.google.errorprone:error_prone_core:latest.release'
+    compileOnly 'com.google.errorprone:error_prone_annotation:latest.release'
+    testImplementation("com.google.errorprone:error_prone_test_helpers:latest.release")
+    testImplementation("joda-time:joda-time:2.10.6")
 
-  compileOnly         'com.google.auto.service:auto-service:1.0-rc4'
-  annotationProcessor 'com.google.auto.service:auto-service:1.0-rc4'
+    compileOnly 'com.google.auto.service:auto-service:1.0-rc4'
+    annotationProcessor 'com.google.auto.service:auto-service:1.0-rc4'
 }
 
 

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeClassBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeClassBan.java
@@ -18,6 +18,7 @@ import com.sun.source.tree.ImportTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
@@ -25,27 +26,17 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
 
 /**
- * Check for usage of Joda-Time's {@code org.joda.time.base.* org.joda.time.chrono.*
- * org.joda.time.convert.*, org.joda.time.field.*, org.joda.time.format.*, org.joda.time.tz.*,
- * org.joda.time.Chronology, org.joda.time.DateMidnight, org.joda.time.DateTimeComparator,
- * org.joda.time.DateTimeField, org.joda.time.DateTimeFieldType, org.joda.time.DateTimeUtils,
- * org.joda.time.Days, org.joda.time.DurationField, org.joda.time.DurationFieldType,
- * org.joda.time.Hours, org.joda.time.IllegalFieldValueException, org.joda.time.IllegalInstantException,
- * org.joda.time.JodaTimePermission, org.joda.time.Minutes, org.joda.time.MonthDay,
- * org.joda.time.Months, org.joda.time.MutableDateTime, org.joda.time.MutableInterval,
- * org.joda.time.MutablePeriod, org.joda.time.Partial, org.joda.time.PeriodType,
- * org.joda.time.ReadWritableDateTime, org.joda.time.ReadWritableInstant,
- * org.joda.time.ReadWritableInterval, org.joda.time.ReadWritablePeriod org.joda.time.Seconds,
- * org.joda.time.TimeOfDay org.joda.time.Weeks org.joda.time.YearMonthDay org.joda.time.Years}.
+ * Check for usage of some Joda-Time's classes, which can be found in {@code CLASS_NAMES}. Also
+ * checks for the usage of several Joda-Time packages, which can be found in {@code PACKAGE_NAMES}.
  * These calls are banned due to their incompatibility with cross platform development.
  */
 @BugPattern(
     name = "JodaTimeClassBan",
-    summary = "Joda Time cross platform class ban",
+    summary = "Bans the usage of certain Joda-Time classes and packages for cross platform use.",
     explanation =
-        "The usage of several Joda Time classes are banned from cross platform development due"
-            + " to incompatibilities. They are unsupported on the web and should also not be"
-            + " used on supported platforms.",
+        "The usage of several Joda-Time classes and packages are banned from cross"
+            + " platform development due to incompatibilities. They are unsupported on the web"
+            + " and should also not be used on supported platforms.",
     severity = ERROR)
 public class JodaTimeClassBan extends BugChecker
     implements MethodInvocationTreeMatcher, NewClassTreeMatcher, ImportTreeMatcher,
@@ -53,8 +44,8 @@ public class JodaTimeClassBan extends BugChecker
 
   private static final ImmutableSet<String> PACKAGE_NAMES =
       ImmutableSet.of(
-          "org.joda.time.base.", "org.joda.time.chrono", "org.joda.time.convert",
-          "org.joda.time.field", "org.joda.time.format", "org.joda.time.tz"
+          "org.joda.time.chrono", "org.joda.time.convert", "org.joda.time.field",
+          "org.joda.time.format", "org.joda.time.tz"
       );
 
   private static final ImmutableSet<String> CLASS_NAMES =
@@ -74,6 +65,32 @@ public class JodaTimeClassBan extends BugChecker
           "org.joda.time.TimeOfDay", "org.joda.time.Weeks", "org.joda.time.YearMonthDay"
       );
 
+  public Description standardMessage(Tree tree, String target) {
+    return buildDescription(tree)
+        .setMessage(
+            String.format("Use of %s has been banned due to cross"
+                + " platform incompatibility.", target))
+        .build();
+  }
+
+  public Description methodCallMessage(Tree tree, String method, String target) {
+    return buildDescription(tree)
+        .setMessage(
+            String.format("Use of %s is not allowed, as %s has been banned due to cross"
+                + " platform incompatibility.", method, target))
+        .build();
+  }
+
+  public Description constructorMessage(Tree tree, String constructor, String target) {
+    return buildDescription(tree)
+        .setMessage(
+            String.format(
+                "Use of this constructor (%s) is not allowed, as %s"
+                    + " is banned due to cross platform incompatibility.",
+                constructor, target))
+        .build();
+  }
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
 
@@ -83,61 +100,35 @@ public class JodaTimeClassBan extends BugChecker
 
     if (methodType != null && methodSymbol != null) {
 
-      //checks receiver
+      // checks receiver for banned classes/packages
       if (CLASS_NAMES.contains(methodRecvType.toString())) {
-        return buildDescription(tree)
-            .setMessage(
-                String.format("Use of %s has been banned due to cross"
-                    + " platform incompatibility.", methodRecvType))
-            .build();
+        return standardMessage(tree, methodRecvType.toString());
       } else if (PACKAGE_NAMES.contains(methodSymbol.packge().toString())) {
-        return buildDescription(tree)
-            .setMessage(
-                String.format("Use of %s has been banned due to cross"
-                    + " platform incompatibility.", methodSymbol.packge()))
-            .build();
+        return standardMessage(tree, methodSymbol.packge().toString());
       }
 
-      //checks caller
+      // checks caller for banned classes
       if (CLASS_NAMES.contains(methodType.toString())) {
-        return buildDescription(tree)
-            .setMessage(
-                String.format("Use of %s is not allowed, as %s has been banned due to cross"
-                    + " platform incompatibility.", methodSymbol, methodType))
-            .build();
+        return methodCallMessage(tree, methodSymbol.toString(), methodType.toString());
       }
-
+      // checks caller for banned packages
       for (String pack_name : PACKAGE_NAMES) {
         if (methodType.toString().startsWith(pack_name)) {
-          return buildDescription(tree)
-              .setMessage(
-                  String.format("Use of %s is not allowed, as %s has been banned due to cross"
-                      + " platform incompatibility.", methodSymbol, pack_name))
-              .build();
+          return methodCallMessage(tree, methodSymbol.toString(), pack_name);
         }
       }
     }
 
-    //checks arguments
+    // checks arguments for banned classes/packages
     for (ExpressionTree arg : tree.getArguments()) {
       Symbol argSymbol = ASTHelpers.getSymbol(arg);
       Type argType = ASTHelpers.getType(arg);
 
-      if (argSymbol != null && argType != null) {
+      if (argSymbol != null && argType != null && methodSymbol != null) {
         if (CLASS_NAMES.contains(argType.toString())) {
-          return buildDescription(tree)
-              .setMessage(
-                  String.format("Use of %s has been banned due to cross"
-                          + " platform incompatibility.",
-                      methodSymbol))
-              .build();
+          return standardMessage(tree, methodSymbol.toString());
         } else if (PACKAGE_NAMES.contains(argSymbol.packge().toString())) {
-          return buildDescription(tree)
-              .setMessage(
-                  String.format("Use of %s has been banned due to cross"
-                          + " platform incompatibility.",
-                      methodSymbol))
-              .build();
+          return standardMessage(tree, methodSymbol.toString());
         }
       }
     }
@@ -151,44 +142,21 @@ public class JodaTimeClassBan extends BugChecker
     MethodSymbol constructorSymbol = ASTHelpers.getSymbol(tree);
     Type constructorType = ASTHelpers.getType(tree);
 
-    //checks constructor
     if (constructorSymbol != null && constructorType != null) {
+      // checks constructor for banned classes/packages
       if (CLASS_NAMES.contains(constructorType.toString())) {
-        return buildDescription(tree)
-            .setMessage(
-                String.format("Use of %s has been banned due to cross"
-                        + " platform incompatibility.",
-                    constructorType))
-            .build();
+        return standardMessage(tree, constructorType.toString());
       } else if (PACKAGE_NAMES.contains(constructorSymbol.packge().toString())) {
-        return buildDescription(tree)
-            .setMessage(
-                String.format("Use of %s has been banned due to cross"
-                        + " platform incompatibility.",
-                    constructorSymbol.packge().toString()))
-            .build();
+        return standardMessage(tree, constructorSymbol.packge().toString());
       }
-    }
 
-    //checks parameters
-    if (constructorSymbol != null) {
+      // checks parameters for banned classes/packages
       for (VarSymbol param : constructorSymbol.getParameters()) {
         if (CLASS_NAMES.contains(param.type.toString())) {
-          return buildDescription(tree)
-              .setMessage(
-                  String.format(
-                      "Use of this constructor (%s) is not allowed, as %s"
-                          + " is banned due to cross platform incompatibility.",
-                      constructorSymbol, param.type.toString()))
-              .build();
+          return constructorMessage(tree, constructorSymbol.toString(), param.type.toString());
         } else if (PACKAGE_NAMES.contains(param.packge().toString())) {
-          return buildDescription(tree)
-              .setMessage(
-                  String.format(
-                      "Use of this constructor (%s) is not allowed, as %s"
-                          + " is banned due to cross platform incompatibility.",
-                      constructorSymbol, param.packge().toString()))
-              .build();
+          return constructorMessage(tree, constructorSymbol.toString(),
+              param.packge().toString());
         }
       }
     }
@@ -201,11 +169,7 @@ public class JodaTimeClassBan extends BugChecker
 
     if (CLASS_NAMES.contains(importSymbol.toString()) ||
         PACKAGE_NAMES.contains(importSymbol.packge().toString())) {
-      return buildDescription(tree)
-          .setMessage(
-              String.format("Use of %s has been banned due to cross"
-                  + " platform incompatibility.", importSymbol.toString()))
-          .build();
+      return standardMessage(tree, importSymbol.toString());
     }
 
     return Description.NO_MATCH;
@@ -217,20 +181,12 @@ public class JodaTimeClassBan extends BugChecker
 
     if (varType != null) {
       if (CLASS_NAMES.contains(varType.toString())) {
-        return buildDescription(tree)
-            .setMessage(
-                String.format("Use of %s has been banned due to cross"
-                    + " platform incompatibility.", varType))
-            .build();
+        return standardMessage(tree, varType.toString());
       }
 
       for (String packName : PACKAGE_NAMES) {
         if (varType.toString().startsWith(packName)) {
-          return buildDescription(tree)
-              .setMessage(
-                  String.format("Use of %s has been banned due to cross"
-                      + " platform incompatibility.", packName))
-              .build();
+          return standardMessage(tree, packName);
         }
       }
     }
@@ -245,24 +201,15 @@ public class JodaTimeClassBan extends BugChecker
     if (methodType != null) {
       methodType = methodType.getReturnType();
       if (CLASS_NAMES.contains(methodType.toString())) {
-        return buildDescription(tree)
-            .setMessage(
-                String.format("Use of %s has been banned due to cross"
-                    + " platform incompatibility.", methodType))
-            .build();
+        return standardMessage(tree, methodType.toString());
       }
 
       for (String packName : PACKAGE_NAMES) {
         if (methodType.toString().startsWith(packName)) {
-          return buildDescription(tree)
-              .setMessage(
-                  String.format("Use of %s has been banned due to cross"
-                      + " platform incompatibility.", packName))
-              .build();
+          return standardMessage(tree, packName);
         }
       }
     }
-
     return Description.NO_MATCH;
   }
 }

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeClassBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeClassBan.java
@@ -1,0 +1,269 @@
+package com.google.errorprone.xplat.checker;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.ImportTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Type;
+
+/**
+ * Check for usage of Joda-Time's {@code org.joda.time.base.* org.joda.time.chrono.*
+ * org.joda.time.convert.*, org.joda.time.field.*, org.joda.time.format.*, org.joda.time.tz.*,
+ * org.joda.time.Chronology, org.joda.time.DateMidnight, org.joda.time.DateTimeComparator,
+ * org.joda.time.DateTimeField, org.joda.time.DateTimeFieldType, org.joda.time.DateTimeUtils,
+ * org.joda.time.Days, org.joda.time.DurationField, org.joda.time.DurationFieldType,
+ * org.joda.time.Hours, org.joda.time.IllegalFieldValueException, org.joda.time.IllegalInstantException,
+ * org.joda.time.JodaTimePermission, org.joda.time.Minutes, org.joda.time.MonthDay,
+ * org.joda.time.Months, org.joda.time.MutableDateTime, org.joda.time.MutableInterval,
+ * org.joda.time.MutablePeriod, org.joda.time.Partial, org.joda.time.PeriodType,
+ * org.joda.time.ReadWritableDateTime, org.joda.time.ReadWritableInstant,
+ * org.joda.time.ReadWritableInterval, org.joda.time.ReadWritablePeriod org.joda.time.Seconds,
+ * org.joda.time.TimeOfDay org.joda.time.Weeks org.joda.time.YearMonthDay org.joda.time.Years}.
+ * These calls are banned due to their incompatibility with cross platform development.
+ */
+@BugPattern(
+    name = "JodaTimeClassBan",
+    summary = "Joda Time cross platform class ban",
+    explanation =
+        "The usage of several Joda Time classes are banned from cross platform development due"
+            + " to incompatibilities. They are unsupported on the web and should also not be"
+            + " used on supported platforms.",
+    severity = ERROR)
+public class JodaTimeClassBan extends BugChecker
+    implements MethodInvocationTreeMatcher, NewClassTreeMatcher, ImportTreeMatcher,
+    VariableTreeMatcher, MethodTreeMatcher {
+
+  private static final ImmutableSet<String> PACKAGE_NAMES =
+      ImmutableSet.of(
+          "org.joda.time.base.", "org.joda.time.chrono", "org.joda.time.convert",
+          "org.joda.time.field", "org.joda.time.format", "org.joda.time.tz"
+      );
+
+  private static final ImmutableSet<String> CLASS_NAMES =
+      ImmutableSet.of(
+          "org.joda.time.Chronology", "org.joda.time.DateMidnight",
+          "org.joda.time.DateTimeComparator", "org.joda.time.DateTimeField",
+          "org.joda.time.DateTimeFieldType", "org.joda.time.DateTimeUtils",
+          "org.joda.time.Days", "org.joda.time.DurationField", "org.joda.time.DurationFieldType",
+          "org.joda.time.Hours", "org.joda.time.IllegalFieldValueException",
+          "org.joda.time.IllegalInstantException", "org.joda.time.JodaTimePermission",
+          "org.joda.time.Minutes", "org.joda.time.MonthDay", "org.joda.time.Months",
+          "org.joda.time.MutableDateTime", "org.joda.time.MutableInterval",
+          "org.joda.time.MutablePeriod", "org.joda.time.Partial", "org.joda.time.Years",
+          "org.joda.time.PeriodType", "org.joda.time.ReadWritableDateTime",
+          "org.joda.time.ReadWritableInstant", "org.joda.time.ReadWritableInterval",
+          "org.joda.time.ReadWritablePeriod", "org.joda.time.Seconds",
+          "org.joda.time.TimeOfDay", "org.joda.time.Weeks", "org.joda.time.YearMonthDay"
+      );
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+
+    Symbol methodSymbol = ASTHelpers.getSymbol(tree);
+    Type methodRecvType = ASTHelpers.getReceiverType(tree);
+    Type methodType = ASTHelpers.getType(tree);
+
+    if (methodType != null && methodSymbol != null) {
+
+      //checks receiver
+      if (CLASS_NAMES.contains(methodRecvType.toString())) {
+        return buildDescription(tree)
+            .setMessage(
+                String.format("Use of %s has been banned due to cross"
+                    + " platform incompatibility.", methodRecvType))
+            .build();
+      } else if (PACKAGE_NAMES.contains(methodSymbol.packge().toString())) {
+        return buildDescription(tree)
+            .setMessage(
+                String.format("Use of %s has been banned due to cross"
+                    + " platform incompatibility.", methodSymbol.packge()))
+            .build();
+      }
+
+      //checks caller
+      if (CLASS_NAMES.contains(methodType.toString())) {
+        return buildDescription(tree)
+            .setMessage(
+                String.format("Use of %s is not allowed, as %s has been banned due to cross"
+                    + " platform incompatibility.", methodSymbol, methodType))
+            .build();
+      }
+
+      for (String pack_name : PACKAGE_NAMES) {
+        if (methodType.toString().startsWith(pack_name)) {
+          return buildDescription(tree)
+              .setMessage(
+                  String.format("Use of %s is not allowed, as %s has been banned due to cross"
+                      + " platform incompatibility.", methodSymbol, pack_name))
+              .build();
+        }
+      }
+    }
+
+    //checks arguments
+    for (ExpressionTree arg : tree.getArguments()) {
+      Symbol argSymbol = ASTHelpers.getSymbol(arg);
+      Type argType = ASTHelpers.getType(arg);
+
+      if (argSymbol != null && argType != null) {
+        if (CLASS_NAMES.contains(argType.toString())) {
+          return buildDescription(tree)
+              .setMessage(
+                  String.format("Use of %s has been banned due to cross"
+                          + " platform incompatibility.",
+                      methodSymbol))
+              .build();
+        } else if (PACKAGE_NAMES.contains(argSymbol.packge().toString())) {
+          return buildDescription(tree)
+              .setMessage(
+                  String.format("Use of %s has been banned due to cross"
+                          + " platform incompatibility.",
+                      methodSymbol))
+              .build();
+        }
+      }
+    }
+
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchNewClass(NewClassTree tree, VisitorState state) {
+
+    MethodSymbol constructorSymbol = ASTHelpers.getSymbol(tree);
+    Type constructorType = ASTHelpers.getType(tree);
+
+    //checks constructor
+    if (constructorSymbol != null && constructorType != null) {
+      if (CLASS_NAMES.contains(constructorType.toString())) {
+        return buildDescription(tree)
+            .setMessage(
+                String.format("Use of %s has been banned due to cross"
+                        + " platform incompatibility.",
+                    constructorType))
+            .build();
+      } else if (PACKAGE_NAMES.contains(constructorSymbol.packge().toString())) {
+        return buildDescription(tree)
+            .setMessage(
+                String.format("Use of %s has been banned due to cross"
+                        + " platform incompatibility.",
+                    constructorSymbol.packge().toString()))
+            .build();
+      }
+    }
+
+    //checks parameters
+    if (constructorSymbol != null) {
+      for (VarSymbol param : constructorSymbol.getParameters()) {
+        if (CLASS_NAMES.contains(param.type.toString())) {
+          return buildDescription(tree)
+              .setMessage(
+                  String.format(
+                      "Use of this constructor (%s) is not allowed, as %s"
+                          + " is banned due to cross platform incompatibility.",
+                      constructorSymbol, param.type.toString()))
+              .build();
+        } else if (PACKAGE_NAMES.contains(param.packge().toString())) {
+          return buildDescription(tree)
+              .setMessage(
+                  String.format(
+                      "Use of this constructor (%s) is not allowed, as %s"
+                          + " is banned due to cross platform incompatibility.",
+                      constructorSymbol, param.packge().toString()))
+              .build();
+        }
+      }
+    }
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchImport(ImportTree tree, VisitorState state) {
+    Symbol importSymbol = ASTHelpers.getSymbol(tree.getQualifiedIdentifier());
+
+    if (CLASS_NAMES.contains(importSymbol.toString()) ||
+        PACKAGE_NAMES.contains(importSymbol.packge().toString())) {
+      return buildDescription(tree)
+          .setMessage(
+              String.format("Use of %s has been banned due to cross"
+                  + " platform incompatibility.", importSymbol.toString()))
+          .build();
+    }
+
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    Type varType = ASTHelpers.getType(tree);
+
+    if (varType != null) {
+      if (CLASS_NAMES.contains(varType.toString())) {
+        return buildDescription(tree)
+            .setMessage(
+                String.format("Use of %s has been banned due to cross"
+                    + " platform incompatibility.", varType))
+            .build();
+      }
+
+      for (String packName : PACKAGE_NAMES) {
+        if (varType.toString().startsWith(packName)) {
+          return buildDescription(tree)
+              .setMessage(
+                  String.format("Use of %s has been banned due to cross"
+                      + " platform incompatibility.", packName))
+              .build();
+        }
+      }
+    }
+
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchMethod(MethodTree tree, VisitorState state) {
+    Type methodType = ASTHelpers.getType(tree);
+
+    if (methodType != null) {
+      methodType = methodType.getReturnType();
+      if (CLASS_NAMES.contains(methodType.toString())) {
+        return buildDescription(tree)
+            .setMessage(
+                String.format("Use of %s has been banned due to cross"
+                    + " platform incompatibility.", methodType))
+            .build();
+      }
+
+      for (String packName : PACKAGE_NAMES) {
+        if (methodType.toString().startsWith(packName)) {
+          return buildDescription(tree)
+              .setMessage(
+                  String.format("Use of %s has been banned due to cross"
+                      + " platform incompatibility.", packName))
+              .build();
+        }
+      }
+    }
+
+    return Description.NO_MATCH;
+  }
+}
+

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeClassBanTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeClassBanTest.java
@@ -1,0 +1,34 @@
+package com.google.errorprone.xplat.checker;
+
+import com.google.common.base.Predicates;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link MyCustomCheck}.
+ */
+@RunWith(JUnit4.class)
+public class JodaTimeClassBanTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setup() {
+    compilationHelper = CompilationTestHelper.newInstance(JodaTimeClassBan.class, getClass());
+  }
+
+  @Test
+  public void customCheckPositiveCases() {
+    compilationHelper.addSourceFile("JodaTimeClassBanPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void customCheckNegativeCases() {
+    compilationHelper.addSourceFile("JodaTimeClassBanNegativeCases.java").doTest();
+  }
+
+}
+

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanNegativeCases.java
@@ -1,0 +1,53 @@
+package com.google.errorprone.xplat.checker.testdata;
+
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDateTime;
+
+
+public class JodaTimeClassBanNegativeCases {
+
+  public class aClass {
+
+    //test allowed field
+    private DateTime time;
+
+    //test allowed constructor
+    public aClass(DateTime time) {
+      this.time = time;
+    }
+
+    //test allowed method
+    private DateTime getTime(DateTime time) {
+      return time;
+    }
+  }
+
+  //allowed function
+  private static DateTime goodLocalDateTimeUse() {
+    LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);
+    return new DateTime(ldt.getYear(), ldt.getMonthOfYear(), ldt.getDayOfYear(), ldt.getHourOfDay(),
+        ldt.getMinuteOfHour(), ldt.getSecondOfMinute(), ldt.getMillisOfSecond(),
+        DateTimeZone.forID("America/New_York"))
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+
+  }
+
+  public static void main(String[] args) {
+    //test allowed new
+    DateTime dt = new DateTime();
+
+    DateTime dt2 = goodLocalDateTimeUse();
+
+    //test allowed method call
+    dt2.dayOfYear();
+
+    //test allowed local var
+    DateTime dt3;
+
+    System.out.println(dt.toString());
+  }
+
+
+}

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanNegativeCases.java
@@ -10,21 +10,21 @@ public class JodaTimeClassBanNegativeCases {
 
   public class aClass {
 
-    //test allowed field
+    // test allowed field
     private DateTime time;
 
-    //test allowed constructor
+    // test allowed constructor
     public aClass(DateTime time) {
       this.time = time;
     }
 
-    //test allowed method
+    // test allowed method
     private DateTime getTime(DateTime time) {
       return time;
     }
   }
 
-  //allowed function
+  // allowed function
   private static DateTime goodLocalDateTimeUse() {
     LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);
     return new DateTime(ldt.getYear(), ldt.getMonthOfYear(), ldt.getDayOfYear(), ldt.getHourOfDay(),
@@ -35,15 +35,15 @@ public class JodaTimeClassBanNegativeCases {
   }
 
   public static void main(String[] args) {
-    //test allowed new
+    // test allowed new
     DateTime dt = new DateTime();
 
     DateTime dt2 = goodLocalDateTimeUse();
 
-    //test allowed method call
+    // test allowed method call
     dt2.dayOfYear();
 
-    //test allowed local var
+    // test allowed local var
     DateTime dt3;
 
     System.out.println(dt.toString());

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanPositiveCases.java
@@ -1,0 +1,170 @@
+package com.google.errorprone.xplat.checker.testdata;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDateTime;
+//tests banned imports
+// BUG: Diagnostic contains: Use of org.joda.time.Days
+import org.joda.time.Days;
+// BUG: Diagnostic contains: Use of org.joda.time.MutableDateTime
+import org.joda.time.MutableDateTime;
+// BUG: Diagnostic contains: Use of org.joda.time.chrono.BuddhistChronology
+import org.joda.time.chrono.BuddhistChronology;
+// BUG: Diagnostic contains: Use of org.joda.time.Chronology
+import org.joda.time.Chronology;
+// BUG: Diagnostic contains: Use of org.joda.time.DateMidnight
+import org.joda.time.DateMidnight;
+//tests banned package import
+// BUG: Diagnostic contains: Use of org.joda.time.tz.FixedDateTimeZone
+import org.joda.time.tz.FixedDateTimeZone;
+
+
+public class JodaTimeClassBanPositiveCases {
+
+  public void mutableDate() {
+    //test constructor from banned class
+    // BUG: Diagnostic contains: Use of org.joda.time.MutableDateTime
+    MutableDateTime dateTime = new MutableDateTime();
+
+    //test local var from banned class
+    // BUG: Diagnostic contains: Use of org.joda.time.MutableDateTime
+    MutableDateTime time;
+
+    //test method call from banned class
+    // BUG: Diagnostic contains: Use of org.joda.time.MutableDateTime
+    dateTime.add(2);
+
+    //test method call on banned instantiated class
+    // BUG: Diagnostic contains: Use of org.joda.time.MutableDateTime
+    System.out.println(dateTime.toString());
+
+  }
+
+  public void chrono() {
+    DateTime dt = new DateTime();
+
+    //test constructor from banned package
+    // BUG: Diagnostic contains: Use of org.joda.time.chrono
+    BuddhistChronology chr = BuddhistChronology.getInstance();
+
+    //test method from banned package
+    // BUG: Diagnostic contains: Use of org.joda.time.chrono
+    chr.toString();
+
+    //test local var from banned package
+    // BUG: Diagnostic contains: Use of org.joda.time.chrono
+    BuddhistChronology ch2;
+
+    //test method that returns banned type
+    // BUG: Diagnostic contains: Use of withChronology(org.joda.time.Chronology)
+    DateTime dtBuddhist = dt.withChronology(BuddhistChronology.getInstance());
+
+    System.out.println(dtBuddhist.getYear());
+  }
+
+  public void tzTime() {
+    //test constructor from banned package
+    // BUG: Diagnostic contains: Use of org.joda.time.tz
+    FixedDateTimeZone time = new FixedDateTimeZone("1", "1", 1, 1);
+
+    //test method from banned package
+    // BUG: Diagnostic contains: Use of org.joda.time.tz
+    time.getStandardOffset(1);
+  }
+
+  //test method that returns banned class
+  // BUG: Diagnostic contains: Use of org.joda.time.DateMidnight
+  private DateMidnight doNotUseDateMidnight() {
+
+    //test method from allowed class that returns banned type
+    // BUG: Diagnostic contains: Use of toDateMidnight() is not allowed, as org.joda.time.DateMidnight
+    return goodLocalDateTimeUse().toDateMidnight();
+  }
+
+  private void implicitBannedClassUse() {
+    //test method from allowed class that returns banned type
+    // BUG: Diagnostic contains: Use of toYearMonthDay() is not allowed, as org.joda.time.YearMonthDay
+    goodLocalDateTimeUse().toYearMonthDay();
+  }
+
+  //test method declaration that has a parameter with a banned type
+  // BUG: Diagnostic contains: Use of org.joda.time.Chronology
+  private DateTime bannedParameterTypes(String s, Chronology c) {
+    System.out.println(s);
+
+    //tests a method that has an invalid paramater
+    // BUG: Diagnostic contains: Use of toDateTime(org.joda.time.Chronology)
+    return goodLocalDateTimeUse().toDateTime(BuddhistChronology.getInstance());
+  }
+
+  private LocalDateTime badConstructor() {
+    //tests the use of a constructor that has arguments that are banned
+    // BUG: Diagnostic contains: Use of this constructor (LocalDateTime(long,org.joda.time.Chronology))
+    return new LocalDateTime(2, BuddhistChronology.getInstance());
+  }
+
+  // Create an 8 AM ET then convert it to PT. Bad case.
+  private DateTime badLocalDateTimeUse() {
+    LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);
+    return ldt.toDateTime(DateTimeZone.forID("America/New_York"))
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  // Create an 8 AM ET then convert it to PT.
+  private DateTime goodLocalDateTimeUse() {
+    LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);
+    return new DateTime(ldt.getYear(), ldt.getMonthOfYear(), ldt.getDayOfYear(), ldt.getHourOfDay(),
+        ldt.getMinuteOfHour(), ldt.getSecondOfMinute(), ldt.getMillisOfSecond(),
+        DateTimeZone.forID("America/New_York"))
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+
+  }
+
+  private class Illegial {
+
+    // BUG: Diagnostic contains: Use of org.joda.time.Chronology
+    private Chronology chrono;
+
+    //tests a created method that has a parameter with a banned type
+    // BUG: Diagnostic contains: Use of org.joda.time.Chronology
+    public Illegial(Chronology chrono) {
+      this.chrono = chrono;
+    }
+
+    //tests a created method that returns a banned type
+    // BUG: Diagnostic contains: Use of org.joda.time.Chronology
+    private Chronology returnChrono() {
+      return this.chrono;
+    }
+  }
+
+  private class Illegial2 {
+
+    //tests a banned field from a banned package
+    // BUG: Diagnostic contains: Use of org.joda.time.tz
+    private FixedDateTimeZone time;
+
+    //tests a created method that has a parameter with a banned type from a package
+    // BUG: Diagnostic contains: Use of org.joda.time.tz
+    public Illegial2(FixedDateTimeZone time) {
+      this.time = time;
+    }
+
+    //tests a created method that returns a banned type from a banned package
+    // BUG: Diagnostic contains: Use of org.joda.time.tz
+    private FixedDateTimeZone returnChrono() {
+      return this.time;
+    }
+  }
+
+
+  public static void main(String[] args) {
+    JodaTimeClassBanPositiveCases m = new JodaTimeClassBanPositiveCases();
+
+    //tests a banned class
+    // BUG: Diagnostic contains: Use of org.joda.time.DateMidnight
+    DateMidnight dm = m.doNotUseDateMidnight();
+
+    System.err.println(m.badLocalDateTimeUse());
+  }
+}

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanPositiveCases.java
@@ -22,19 +22,19 @@ import org.joda.time.tz.FixedDateTimeZone;
 public class JodaTimeClassBanPositiveCases {
 
   public void mutableDate() {
-    //test constructor from banned class
+    // test constructor from banned class
     // BUG: Diagnostic contains: Use of org.joda.time.MutableDateTime
     MutableDateTime dateTime = new MutableDateTime();
 
-    //test local var from banned class
+    // test local var from banned class
     // BUG: Diagnostic contains: Use of org.joda.time.MutableDateTime
     MutableDateTime time;
 
-    //test method call from banned class
+    // test method call from banned class
     // BUG: Diagnostic contains: Use of org.joda.time.MutableDateTime
     dateTime.add(2);
 
-    //test method call on banned instantiated class
+    // test method call on banned instantiated class
     // BUG: Diagnostic contains: Use of org.joda.time.MutableDateTime
     System.out.println(dateTime.toString());
 
@@ -43,19 +43,19 @@ public class JodaTimeClassBanPositiveCases {
   public void chrono() {
     DateTime dt = new DateTime();
 
-    //test constructor from banned package
+    // test constructor from banned package
     // BUG: Diagnostic contains: Use of org.joda.time.chrono
     BuddhistChronology chr = BuddhistChronology.getInstance();
 
-    //test method from banned package
+    // test method from banned package
     // BUG: Diagnostic contains: Use of org.joda.time.chrono
     chr.toString();
 
-    //test local var from banned package
+    // test local var from banned package
     // BUG: Diagnostic contains: Use of org.joda.time.chrono
     BuddhistChronology ch2;
 
-    //test method that returns banned type
+    // test method that returns banned type
     // BUG: Diagnostic contains: Use of withChronology(org.joda.time.Chronology)
     DateTime dtBuddhist = dt.withChronology(BuddhistChronology.getInstance());
 
@@ -63,42 +63,42 @@ public class JodaTimeClassBanPositiveCases {
   }
 
   public void tzTime() {
-    //test constructor from banned package
+    // test constructor from banned package
     // BUG: Diagnostic contains: Use of org.joda.time.tz
     FixedDateTimeZone time = new FixedDateTimeZone("1", "1", 1, 1);
 
-    //test method from banned package
+    // test method from banned package
     // BUG: Diagnostic contains: Use of org.joda.time.tz
     time.getStandardOffset(1);
   }
 
-  //test method that returns banned class
+  // test method that returns banned class
   // BUG: Diagnostic contains: Use of org.joda.time.DateMidnight
   private DateMidnight doNotUseDateMidnight() {
 
-    //test method from allowed class that returns banned type
+    // test method from allowed class that returns banned type
     // BUG: Diagnostic contains: Use of toDateMidnight() is not allowed, as org.joda.time.DateMidnight
     return goodLocalDateTimeUse().toDateMidnight();
   }
 
   private void implicitBannedClassUse() {
-    //test method from allowed class that returns banned type
+    // test method from allowed class that returns banned type
     // BUG: Diagnostic contains: Use of toYearMonthDay() is not allowed, as org.joda.time.YearMonthDay
     goodLocalDateTimeUse().toYearMonthDay();
   }
 
-  //test method declaration that has a parameter with a banned type
+  // test method declaration that has a parameter with a banned type
   // BUG: Diagnostic contains: Use of org.joda.time.Chronology
   private DateTime bannedParameterTypes(String s, Chronology c) {
     System.out.println(s);
 
-    //tests a method that has an invalid paramater
+    // tests a method that has an invalid paramater
     // BUG: Diagnostic contains: Use of toDateTime(org.joda.time.Chronology)
     return goodLocalDateTimeUse().toDateTime(BuddhistChronology.getInstance());
   }
 
   private LocalDateTime badConstructor() {
-    //tests the use of a constructor that has arguments that are banned
+    // tests the use of a constructor that has arguments that are banned
     // BUG: Diagnostic contains: Use of this constructor (LocalDateTime(long,org.joda.time.Chronology))
     return new LocalDateTime(2, BuddhistChronology.getInstance());
   }
@@ -125,13 +125,13 @@ public class JodaTimeClassBanPositiveCases {
     // BUG: Diagnostic contains: Use of org.joda.time.Chronology
     private Chronology chrono;
 
-    //tests a created method that has a parameter with a banned type
+    // tests a created method that has a parameter with a banned type
     // BUG: Diagnostic contains: Use of org.joda.time.Chronology
     public Illegial(Chronology chrono) {
       this.chrono = chrono;
     }
 
-    //tests a created method that returns a banned type
+    // tests a created method that returns a banned type
     // BUG: Diagnostic contains: Use of org.joda.time.Chronology
     private Chronology returnChrono() {
       return this.chrono;
@@ -140,17 +140,17 @@ public class JodaTimeClassBanPositiveCases {
 
   private class Illegial2 {
 
-    //tests a banned field from a banned package
+    // tests a banned field from a banned package
     // BUG: Diagnostic contains: Use of org.joda.time.tz
     private FixedDateTimeZone time;
 
-    //tests a created method that has a parameter with a banned type from a package
+    // tests a created method that has a parameter with a banned type from a package
     // BUG: Diagnostic contains: Use of org.joda.time.tz
     public Illegial2(FixedDateTimeZone time) {
       this.time = time;
     }
 
-    //tests a created method that returns a banned type from a banned package
+    // tests a created method that returns a banned type from a banned package
     // BUG: Diagnostic contains: Use of org.joda.time.tz
     private FixedDateTimeZone returnChrono() {
       return this.time;
@@ -161,7 +161,7 @@ public class JodaTimeClassBanPositiveCases {
   public static void main(String[] args) {
     JodaTimeClassBanPositiveCases m = new JodaTimeClassBanPositiveCases();
 
-    //tests a banned class
+    // tests a banned class
     // BUG: Diagnostic contains: Use of org.joda.time.DateMidnight
     DateMidnight dm = m.doNotUseDateMidnight();
 


### PR DESCRIPTION
Bans the use of a list of Joda Time classes that are not suitable for cross platform use.

Applications where these classes are banned include

- Variables
- Method declarations
- Method calls
- Use of new
- Import statements