### PR TITLE
Checker to ban java.util.Calendar, with annotation override

### DIFF
--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/AllowLegacyTime.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/AllowLegacyTime.java
@@ -8,6 +8,10 @@ import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
 
 import java.lang.annotation.Target;
 
+/**
+ * Annotation that indicates the explicit use of java.util.Calendar, in order to override the
+ * CalendarClassBan xplat error prone checker.
+ */
 @Target({CONSTRUCTOR, METHOD, PARAMETER, FIELD, LOCAL_VARIABLE})
 public @interface AllowLegacyTime {
 

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/AllowLegacyTime.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/AllowLegacyTime.java
@@ -1,9 +1,14 @@
 package com.google.errorprone.xplat.checker;
 
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+
 import java.lang.annotation.Target;
 
-@Target({ElementType.TYPE})
+@Target({CONSTRUCTOR, METHOD, PARAMETER, FIELD, LOCAL_VARIABLE})
 public @interface AllowLegacyTime {
 
 }

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/AllowLegacyTime.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/AllowLegacyTime.java
@@ -1,0 +1,9 @@
+package com.google.errorprone.xplat.checker;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+public @interface AllowLegacyTime {
+
+}

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
@@ -1,0 +1,60 @@
+package com.google.errorprone.xplat.checker;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.Arrays;
+
+
+@BugPattern(
+    name = "JodaTimeClassBan",
+    summary = "java.util.Calendar ban - override with @AllowLegacyTime",
+    explanation =
+        "The usage of java.util.Calendar is banned from cross platform development due"
+            + " to incompatibilities. If one is sure that they must use it, the "
+            + "@AllowLegacyTime annotation will allowed to override the error.",
+    severity = ERROR)
+public class CalendarClassBan extends BugChecker implements MethodInvocationTreeMatcher {
+
+
+  private static final String CALENDAR_CLASS = "java.util.Calendar";
+
+
+  private static final Matcher<ExpressionTree> HAS_ALLOWLEGACYTIME_ANNOTATION =
+      Matchers.hasAnnotation(AllowLegacyTime.class.getCanonicalName());
+
+
+  private static final Matcher<ExpressionTree> METHOD_MATCHER =
+      Matchers.anyOf(
+          Matchers.instanceMethod().onExactClass(CALENDAR_CLASS),
+          Matchers.staticMethod().onClass(CALENDAR_CLASS)
+      );
+
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+
+    System.out
+        .println(ASTHelpers.enclosingClass(ASTHelpers.getSymbol(tree)));
+
+    if (METHOD_MATCHER.matches(tree, state)) {
+      return buildDescription(tree)
+          .setMessage(
+              String.format("%s is banned for cross platform development due to incompatibilities."
+                      + " If you must use it, please use the @AllowLegacyTime annotation.",
+                  CALENDAR_CLASS))
+          .build();
+    }
+    return Description.NO_MATCH;
+  }
+}
+

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
@@ -5,11 +5,13 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import java.util.Arrays;
@@ -23,13 +25,14 @@ import java.util.Arrays;
             + " to incompatibilities. If one is sure that they must use it, the "
             + "@AllowLegacyTime annotation will allowed to override the error.",
     severity = ERROR)
-public class CalendarClassBan extends BugChecker implements MethodInvocationTreeMatcher {
+public class CalendarClassBan extends BugChecker implements MethodInvocationTreeMatcher,
+    ClassTreeMatcher {
 
 
   private static final String CALENDAR_CLASS = "java.util.Calendar";
 
 
-  private static final Matcher<ExpressionTree> HAS_ALLOWLEGACYTIME_ANNOTATION =
+  private static final Matcher<ClassTree> HAS_ALLOWLEGACYTIME =
       Matchers.hasAnnotation(AllowLegacyTime.class.getCanonicalName());
 
 
@@ -39,20 +42,30 @@ public class CalendarClassBan extends BugChecker implements MethodInvocationTree
           Matchers.staticMethod().onClass(CALENDAR_CLASS)
       );
 
+  private boolean annotated = false;
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
 
     System.out
-        .println(ASTHelpers.enclosingClass(ASTHelpers.getSymbol(tree)));
+        .println(ASTHelpers.getSymbol(tree));
 
-    if (METHOD_MATCHER.matches(tree, state)) {
+    if (METHOD_MATCHER.matches(tree, state) && !this.annotated) {
       return buildDescription(tree)
           .setMessage(
               String.format("%s is banned for cross platform development due to incompatibilities."
                       + " If you must use it, please use the @AllowLegacyTime annotation.",
                   CALENDAR_CLASS))
           .build();
+    }
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchClass(ClassTree tree, VisitorState state) {
+    if (HAS_ALLOWLEGACYTIME.matches(tree, state)) {
+      System.out.println("Found!");
+      this.annotated = true;
     }
     return Description.NO_MATCH;
   }

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
@@ -23,8 +23,8 @@ import com.sun.source.tree.VariableTree;
     summary = "java.util.Calendar ban - override with @AllowLegacyTime.",
     explanation =
         "The usage of java.util.Calendar is banned from cross platform development due"
-            + " to incompatibilities. If one is sure that they must use it, the "
-            + "@AllowLegacyTime annotation will allowed to override the error.",
+            + " to incompatibilities. If one is sure that they must use it, the"
+            + " @AllowLegacyTime annotation will override the error.",
     severity = ERROR)
 public class CalendarClassBan extends BugChecker implements MethodTreeMatcher, VariableTreeMatcher {
 

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
@@ -14,7 +14,10 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 
-
+/**
+ * Checks for usage of java.util.Calendar in Variables, Methods and Parameters. Can be overridden
+ * with the @AllowLegacyTime annotation.
+ */
 @BugPattern(
     name = "JodaTimeClassBan",
     summary = "java.util.Calendar ban - override with @AllowLegacyTime.",
@@ -24,8 +27,7 @@ import com.sun.source.tree.VariableTree;
             + "@AllowLegacyTime annotation will allowed to override the error.",
     severity = ERROR)
 public class CalendarClassBan extends BugChecker implements MethodTreeMatcher, VariableTreeMatcher {
-
-
+  
   private static final String CALENDAR_CLASS = "java.util.Calendar";
 
   private static final Matcher<MethodTree> METHOD_MATCHER =

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
@@ -27,7 +27,7 @@ import com.sun.source.tree.VariableTree;
             + "@AllowLegacyTime annotation will allowed to override the error.",
     severity = ERROR)
 public class CalendarClassBan extends BugChecker implements MethodTreeMatcher, VariableTreeMatcher {
-  
+
   private static final String CALENDAR_CLASS = "java.util.Calendar";
 
   private static final Matcher<MethodTree> METHOD_MATCHER =
@@ -54,7 +54,6 @@ public class CalendarClassBan extends BugChecker implements MethodTreeMatcher, V
 
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
-
     if (METHOD_MATCHER.matches(tree, state)) {
       return message(tree);
     }

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/CalendarClassBan.java
@@ -5,69 +5,65 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
-import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
-import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.util.ASTHelpers;
-import com.sun.source.tree.ClassTree;
-import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.MethodInvocationTree;
-import java.util.Arrays;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
 
 
 @BugPattern(
     name = "JodaTimeClassBan",
-    summary = "java.util.Calendar ban - override with @AllowLegacyTime",
+    summary = "java.util.Calendar ban - override with @AllowLegacyTime.",
     explanation =
         "The usage of java.util.Calendar is banned from cross platform development due"
             + " to incompatibilities. If one is sure that they must use it, the "
             + "@AllowLegacyTime annotation will allowed to override the error.",
     severity = ERROR)
-public class CalendarClassBan extends BugChecker implements MethodInvocationTreeMatcher,
-    ClassTreeMatcher {
+public class CalendarClassBan extends BugChecker implements MethodTreeMatcher, VariableTreeMatcher {
 
 
   private static final String CALENDAR_CLASS = "java.util.Calendar";
 
-
-  private static final Matcher<ClassTree> HAS_ALLOWLEGACYTIME =
-      Matchers.hasAnnotation(AllowLegacyTime.class.getCanonicalName());
-
-
-  private static final Matcher<ExpressionTree> METHOD_MATCHER =
-      Matchers.anyOf(
-          Matchers.instanceMethod().onExactClass(CALENDAR_CLASS),
-          Matchers.staticMethod().onClass(CALENDAR_CLASS)
+  private static final Matcher<MethodTree> METHOD_MATCHER =
+      Matchers.allOf(
+          Matchers.methodReturns(Matchers.isSameType(CALENDAR_CLASS)),
+          Matchers.not(Matchers.hasAnnotation(AllowLegacyTime.class.getCanonicalName()))
       );
 
-  private boolean annotated = false;
+  private static final Matcher<VariableTree> VAR_MATCHER =
+      Matchers.allOf(
+          Matchers.isSameType(CALENDAR_CLASS),
+          Matchers.not(Matchers.hasAnnotation(AllowLegacyTime.class.getCanonicalName()))
+      );
+
+  private Description message(Tree tree) {
+    return buildDescription(tree)
+        .setMessage(
+            String.format("%s is banned for cross platform development due to incompatibilities."
+                    + " If you must use it, please use the @AllowLegacyTime annotation.",
+                CALENDAR_CLASS))
+        .build();
+  }
+
 
   @Override
-  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+  public Description matchMethod(MethodTree tree, VisitorState state) {
 
-    System.out
-        .println(ASTHelpers.getSymbol(tree));
-
-    if (METHOD_MATCHER.matches(tree, state) && !this.annotated) {
-      return buildDescription(tree)
-          .setMessage(
-              String.format("%s is banned for cross platform development due to incompatibilities."
-                      + " If you must use it, please use the @AllowLegacyTime annotation.",
-                  CALENDAR_CLASS))
-          .build();
+    if (METHOD_MATCHER.matches(tree, state)) {
+      return message(tree);
     }
     return Description.NO_MATCH;
   }
 
   @Override
-  public Description matchClass(ClassTree tree, VisitorState state) {
-    if (HAS_ALLOWLEGACYTIME.matches(tree, state)) {
-      System.out.println("Found!");
-      this.annotated = true;
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    if (VAR_MATCHER.matches(tree, state)) {
+      return message(tree);
     }
     return Description.NO_MATCH;
   }
 }
-

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/CalendarClassBanTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/CalendarClassBanTest.java
@@ -1,0 +1,32 @@
+package com.google.errorprone.xplat.checker;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link MyCustomCheck}.
+ */
+@RunWith(JUnit4.class)
+public class CalendarClassBanTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setup() {
+    compilationHelper = CompilationTestHelper.newInstance(CalendarClassBan.class, getClass());
+  }
+
+  @Test
+  public void customCheckPositiveCases() {
+    compilationHelper.addSourceFile("CalendarClassBanPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void customCheckNegativeCases() {
+    compilationHelper.addSourceFile("CalendarClassBanNegativeCases.java").doTest();
+  }
+
+}

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanNegativeCases.java
@@ -4,12 +4,23 @@ import com.google.errorprone.xplat.checker.AllowLegacyTime;
 
 import java.util.Calendar;
 
-@AllowLegacyTime
 public class CalendarClassBanNegativeCases {
 
-  public static void main(String[] args) {
-    Calendar cal = Calendar.getInstance();
+  @AllowLegacyTime
+  private Calendar cal;
 
+  public CalendarClassBanNegativeCases(@AllowLegacyTime Calendar cal) {
+    this.cal = cal;
+  }
+
+  @AllowLegacyTime
+  public Calendar returnCalendar() {
+    return Calendar.getInstance();
+  }
+
+  public void calParam(@AllowLegacyTime Calendar cal) {
+    @AllowLegacyTime
+    Calendar test = Calendar.getInstance();
   }
 
 

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanNegativeCases.java
@@ -1,0 +1,16 @@
+package com.google.errorprone.xplat.checker.testdata;
+
+import com.google.errorprone.xplat.checker.AllowLegacyTime;
+
+import java.util.Calendar;
+
+@AllowLegacyTime
+public class CalendarClassBanNegativeCases {
+
+  public static void main(String[] args) {
+    Calendar cal = Calendar.getInstance();
+
+  }
+
+
+}

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanNegativeCases.java
@@ -6,19 +6,24 @@ import java.util.Calendar;
 
 public class CalendarClassBanNegativeCases {
 
+  // field
   @AllowLegacyTime
   private Calendar cal;
 
+  // constructor param
   public CalendarClassBanNegativeCases(@AllowLegacyTime Calendar cal) {
     this.cal = cal;
   }
 
+  // method
   @AllowLegacyTime
   public Calendar returnCalendar() {
     return Calendar.getInstance();
   }
 
+  // method param
   public void calParam(@AllowLegacyTime Calendar cal) {
+    // local var
     @AllowLegacyTime
     Calendar test = Calendar.getInstance();
   }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanPositiveCases.java
@@ -2,16 +2,27 @@ package com.google.errorprone.xplat.checker.testdata;
 
 import com.google.errorprone.xplat.checker.AllowLegacyTime;
 
-// xBUG: Diagnostic contains:
 import java.util.Calendar;
-
 
 public class CalendarClassBanPositiveCases {
 
-  public static void main(String[] args) {
-    // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
-    Calendar cal = Calendar.getInstance();
+  // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
+  private Calendar cal;
+
+  // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
+  public CalendarClassBanPositiveCases(Calendar cal) {
+    this.cal = cal;
   }
 
+  // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
+  public Calendar returnCalendar() {
+    return Calendar.getInstance();
+  }
+
+  // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
+  public void calParam(Calendar cal) {
+    // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
+    Calendar test = Calendar.getInstance();
+  }
 
 }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanPositiveCases.java
@@ -6,21 +6,26 @@ import java.util.Calendar;
 
 public class CalendarClassBanPositiveCases {
 
+  // tests field
   // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
   private Calendar cal;
 
+  // tests constructor param
   // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
   public CalendarClassBanPositiveCases(Calendar cal) {
     this.cal = cal;
   }
 
+  // tests method
   // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
   public Calendar returnCalendar() {
     return Calendar.getInstance();
   }
 
+  // tests method param
   // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
   public void calParam(Calendar cal) {
+    // tests local var
     // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
     Calendar test = Calendar.getInstance();
   }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CalendarClassBanPositiveCases.java
@@ -1,0 +1,17 @@
+package com.google.errorprone.xplat.checker.testdata;
+
+import com.google.errorprone.xplat.checker.AllowLegacyTime;
+
+// xBUG: Diagnostic contains:
+import java.util.Calendar;
+
+
+public class CalendarClassBanPositiveCases {
+
+  public static void main(String[] args) {
+    // BUG: Diagnostic contains: java.util.Calendar is banned for cross platform development
+    Calendar cal = Calendar.getInstance();
+  }
+
+
+}


### PR DESCRIPTION
A checker that bans the use of java.util.Calendar. It is banned in the following use cases:

- Fields
- Local vars
- method returns
- method parameters
- constructor parameters

This checker can be overridden with the provided annotation `@AllowLegacyTime`
