### PR TITLE
Joda-Time Object parameter ban

### DIFF
--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBan.java
@@ -28,8 +28,8 @@ import java.util.List;
     summary = "Bans the usage of Joda-Time methods and constructors that have an Object parameter.",
     explanation =
         "The usage of Joda-Time methods and constructors that have an Object parameter are"
-            + " banned from cross platform development due to the dangers of passing null as the "
-            + "parameter. If the parameter is a boxed long, it is allowed to be used.",
+            + " banned from cross platform development due to the dangers of passing null as the"
+            + " parameter. If the parameter is a boxed long, it is allowed to be used.",
     severity = ERROR)
 public class JodaTimeObjectParamBan extends BugChecker implements MethodInvocationTreeMatcher,
     NewClassTreeMatcher {
@@ -44,6 +44,7 @@ public class JodaTimeObjectParamBan extends BugChecker implements MethodInvocati
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+
     MethodSymbol symbol = ASTHelpers.getSymbol(tree);
 
     if (symbol != null) {
@@ -70,7 +71,6 @@ public class JodaTimeObjectParamBan extends BugChecker implements MethodInvocati
     MethodSymbol symbol = ASTHelpers.getSymbol(tree);
 
     if (symbol != null) {
-
       List<VarSymbol> argTypes = symbol.params();
 
       for (int i = 0; i < argTypes.size(); i++) {

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBan.java
@@ -1,0 +1,38 @@
+package com.google.errorprone.xplat.checker;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
+
+/**
+ * Bans the usage of Joda-Time methods and constructors that have an Object parameter. If the
+ * parameter that is passed in is a boxed long, it is permitted.
+ */
+@BugPattern(
+    name = "JodaTimeObjectParamBan",
+    summary = "Bans the usage of Joda-Time methods and constructors that have an Object parameter.",
+    explanation =
+        "The usage of Joda-Time methods and constructors that have an Object parameter are"
+            + " banned from cross platform development due to the dangers of passing null as the "
+            + "parameter. If the parameter is a boxed long, it is allowed to be used.",
+    severity = ERROR)
+public class JodaTimeObjectParamBan extends BugChecker implements MethodInvocationTreeMatcher,
+    NewClassTreeMatcher {
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    return null;
+  }
+
+  @Override
+  public Description matchNewClass(NewClassTree tree, VisitorState state) {
+    return null;
+  }
+}

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBan.java
@@ -8,8 +8,16 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
 import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Type;
+import java.util.List;
 
 /**
  * Bans the usage of Joda-Time methods and constructors that have an Object parameter. If the
@@ -26,13 +34,57 @@ import com.sun.source.tree.NewClassTree;
 public class JodaTimeObjectParamBan extends BugChecker implements MethodInvocationTreeMatcher,
     NewClassTreeMatcher {
 
+  private Description message(Tree tree, String type) {
+    return buildDescription(tree)
+        .setMessage(
+            String.format("Use of %s that have java.lang.Object as a parameter"
+                + " are banned unless the parameter is a boxed long.", type))
+        .build();
+  }
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    return null;
+    MethodSymbol symbol = ASTHelpers.getSymbol(tree);
+
+    if (symbol != null) {
+      List<VarSymbol> argTypes = symbol.params();
+
+      for (int i = 0; i < argTypes.size(); i++) {
+        if (argTypes.get(i).asType().toString().equals("java.lang.Object")) {
+          Type argType = ASTHelpers.getType(tree.getArguments().get(i));
+
+          if (!state.getTypes().unboxedType(argType).toString().equals("long")) {
+            return message(tree, "methods");
+          }
+        }
+
+      }
+    }
+
+    return Description.NO_MATCH;
   }
 
   @Override
   public Description matchNewClass(NewClassTree tree, VisitorState state) {
-    return null;
+
+    MethodSymbol symbol = ASTHelpers.getSymbol(tree);
+
+    if (symbol != null) {
+
+      List<VarSymbol> argTypes = symbol.params();
+
+      for (int i = 0; i < argTypes.size(); i++) {
+        if (argTypes.get(i).asType().toString().equals("java.lang.Object")) {
+          Type argType = ASTHelpers.getType(tree.getArguments().get(i));
+
+          if (!state.getTypes().unboxedType(argType).toString().equals("long")) {
+            return message(tree, "constructors");
+          }
+        }
+
+      }
+    }
+
+    return Description.NO_MATCH;
   }
 }

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBanTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBanTest.java
@@ -1,0 +1,34 @@
+package com.google.errorprone.xplat.checker;
+
+import com.google.errorprone.CompilationTestHelper;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link MyCustomCheck}.
+ */
+@RunWith(JUnit4.class)
+public class JodaTimeObjectParamBanTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setup() {
+    compilationHelper = CompilationTestHelper.newInstance(JodaTimeObjectParamBan.class, getClass());
+  }
+
+  @Test
+  public void customCheckPositiveCases() {
+    compilationHelper.addSourceFile("JodaTimeObjectParamPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void customCheckNegativeCases() {
+    compilationHelper.addSourceFile("JodaTimeObjectParamNegativeCases.java").doTest();
+  }
+
+}

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeObjectParamNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeObjectParamNegativeCases.java
@@ -1,0 +1,27 @@
+package com.google.errorprone.xplat.checker.testdata;
+
+import java.util.Date;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDateTime;
+
+
+public class JodaTimeObjectParamNegativeCases {
+
+
+  public static void main(String[] args) {
+
+    // constructor with object param, but using boxed long
+    DateTime time = new DateTime(new Long(1));
+
+    // constructor with non-object param
+    LocalDateTime time2 = new LocalDateTime(2);
+
+    // method with object parameter but using boxed long
+    time2.equals(new Long(1));
+
+    // method with non-object param
+    time.plusYears(1);
+
+
+  }
+}

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeObjectParamPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeObjectParamPositiveCases.java
@@ -1,0 +1,35 @@
+package com.google.errorprone.xplat.checker.testdata;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDateTime;
+
+
+public class JodaTimeObjectParamPositiveCases {
+
+  public static void main(String[] args) {
+    Object ob = null;
+
+    // testing constructor with object param (not boxed long)
+    // BUG: Diagnostic contains: Use of constructors that have java.lang.Object
+    DateTime time = new DateTime(ob);
+
+    LocalDateTime time2 = new LocalDateTime();
+
+    // testing method with object param (not boxed long)
+    // BUG: Diagnostic contains: Use of methods that have java.lang.Object
+    time2.equals(ob);
+
+    // testing method with object param (not boxed long)
+    // BUG: Diagnostic contains: Use of methods that have java.lang.Object
+    time2.equals(null);
+
+    // testing method with object param (not boxed long)
+    // BUG: Diagnostic contains: Use of methods that have java.lang.Object
+    time2.equals(new Double(2.0));
+
+    // testing method with object param (not boxed long)
+    // BUG: Diagnostic contains: Use of methods that have java.lang.Object
+    time2.equals(new String("Hello"));
+
+  }
+}

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeObjectParamPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeObjectParamPositiveCases.java
@@ -25,6 +25,10 @@ public class JodaTimeObjectParamPositiveCases {
 
     // testing method with object param (not boxed long)
     // BUG: Diagnostic contains: Use of methods that have java.lang.Object
+    time2.equals(1L);
+
+    // testing method with object param (not boxed long)
+    // BUG: Diagnostic contains: Use of methods that have java.lang.Object
     time2.equals(new Double(2.0));
 
     // testing method with object param (not boxed long)


### PR DESCRIPTION
Checker that bans the use of Joda-Time methods and constructors that have Object as a parameter, unless the parameter that is passed is a boxed long.