### PR TITLE
Joda-Time Local class checker

### DIFF
--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeLocal.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeLocal.java
@@ -4,26 +4,27 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.NewClassTree;
 
 @BugPattern(
     name = "JodaTimeLocal",
-    summary = "Bans the usage of toDateTime in some Joda-Time classes.",
+    summary = "Bans the usage of timezoned toDateTime in some Joda-Time classes.",
     explanation =
-        "The usage of toDateTime and the timezoned version of Local Joda-Time classes"
-            + "are banned from cross platform development due to incompatibilities."
-            + " A fix using a new DateTime is suggested.",
+        "The usage of timezoned LocalDateTime, LocalDate and LocalTime Joda-Time constructors"
+            + "/toDateTime methods are banned from cross platform development"
+            + " due to incompatibilities. A fix using a new DateTime is suggested.",
     severity = ERROR)
 public class JodaTimeLocal extends BugChecker implements MethodInvocationTreeMatcher,
     NewClassTreeMatcher {
@@ -46,14 +47,58 @@ public class JodaTimeLocal extends BugChecker implements MethodInvocationTreeMat
           // Allow usage by JodaTime itself
           Matchers.not(Matchers.packageStartsWith("org.joda.time")));
 
+  private static final Matcher<ExpressionTree> METHOD_MATCHER =
+      Matchers.allOf(
+          Matchers.anyOf(
+              CLASS_NAMES.stream()
+                  .map(
+                      className ->
+                          Matchers.instanceMethod()
+                              .onExactClass(className)
+                              .named("toDateTime"))
+                  .collect(toImmutableList())),
+          // Allow usage by JodaTime itself
+          Matchers.not(Matchers.packageStartsWith("org.joda.time")));
+
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    return null;
+    if (METHOD_MATCHER.matches(tree, state)) {
+
+      ExpressionTree recv = ASTHelpers.getReceiver(tree);
+
+      String recvSource = state.getSourceForNode(recv);
+
+      return buildDescription(tree)
+          .setMessage(
+              String.format("The use of %s is banned from cross platform development due to"
+                  + " incompatibilities.", ASTHelpers.getSymbol(tree)))
+          .addFix(
+              SuggestedFix.replace(
+                  state.getEndPosition(ASTHelpers.getReceiver(tree)) - state.getSourceForNode(recv)
+                      .length(),
+                  state.getEndPosition(tree),
+                  String.format("new DateTime(%s.getYear(), %s.getMonthOfYear(),"
+                          + " %s.getDayOfYear(), %s.getHourOfDay(),"
+                          + " %s.getMinuteOfHour(), %s.getSecondOfMinute(), %s.getMillisOfSecond(),"
+                          + " %s)", recvSource, recvSource, recvSource, recvSource, recvSource,
+                      recvSource, recvSource, tree.getArguments())))
+          .build();
+    }
+    return Description.NO_MATCH;
   }
 
   @Override
   public Description matchNewClass(NewClassTree tree, VisitorState state) {
-
-    return null;
+    if (CONSTRUCTOR_MATCHER.matches(tree, state)) {
+      return buildDescription(tree)
+          .setMessage(
+              String.format(
+                  "The use of %s is banned from cross platform development due to"
+                      + " incompatibilities. Please use a different constructor.",
+                  ASTHelpers.getSymbol(tree)))
+          .build();
+    }
+    return Description.NO_MATCH;
   }
 }

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeLocal.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeLocal.java
@@ -1,0 +1,59 @@
+package com.google.errorprone.xplat.checker;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
+
+@BugPattern(
+    name = "JodaTimeLocal",
+    summary = "Bans the usage of toDateTime in some Joda-Time classes.",
+    explanation =
+        "The usage of toDateTime and the timezoned version of Local Joda-Time classes"
+            + "are banned from cross platform development due to incompatibilities."
+            + " A fix using a new DateTime is suggested.",
+    severity = ERROR)
+public class JodaTimeLocal extends BugChecker implements MethodInvocationTreeMatcher,
+    NewClassTreeMatcher {
+
+  private static final ImmutableSet<String> CLASS_NAMES =
+      ImmutableSet
+          .of("org.joda.time.LocalDateTime", "org.joda.time.LocalDate", "org.joda.time.LocalTime");
+
+
+  private static final Matcher<ExpressionTree> CONSTRUCTOR_MATCHER =
+      Matchers.allOf(
+          Matchers.anyOf(
+              CLASS_NAMES.stream()
+                  .map(
+                      typeName ->
+                          Matchers.constructor()
+                              .forClass(typeName)
+                              .withParameters("org.joda.time.DateTimeZone"))
+                  .collect(toImmutableList())),
+          // Allow usage by JodaTime itself
+          Matchers.not(Matchers.packageStartsWith("org.joda.time")));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    return null;
+  }
+
+  @Override
+  public Description matchNewClass(NewClassTree tree, VisitorState state) {
+
+    return null;
+  }
+}

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeLocal.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeLocal.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
@@ -132,7 +132,7 @@ public class JodaTimeLocalTest {
             "class Test {",
             "  private DateTime badLocalTimeUse() {",
             "    LocalTime lt = new LocalTime(8, 0, 0, 0);",
-            "    return new DateTime().now(DateTimeZone.forID(\"America / New_York\"))"
+            "    return new DateTime().toDateTime(DateTimeZone.forID(\"America / New_York\"))"
                 + ".withTime(lt)",
             "      .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
             "  }",
@@ -162,7 +162,7 @@ public class JodaTimeLocalTest {
             "class Test {",
             "  private DateTime badLocalTimeUse() {",
             "    LocalTime lt = new LocalTime(8, 0, 0, 0);",
-            "    return new DateTime().now(DateTimeZone.getDefault()).withTime(lt)",
+            "    return new DateTime().toDateTime(DateTimeZone.getDefault()).withTime(lt)",
             "      .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
             "  }",
             "}")
@@ -189,7 +189,7 @@ public class JodaTimeLocalTest {
             "class Test {",
             "  private DateTime badLocalTimeUse() {",
             "    LocalTime lt = new LocalTime(8, 0, 0, 0);",
-            "    return new DateTime().now(DateTimeZone.getDefault()).withTime(lt);",
+            "    return new DateTime().toDateTime(DateTimeZone.getDefault()).withTime(lt);",
             "  }",
             "}")
         .doTest();
@@ -319,8 +319,8 @@ public class JodaTimeLocalTest {
             "class Test {",
             "  private DateTime badLocalDateUse() {",
             "    LocalDate ld = new LocalDate(2020, 6, 2);",
-            "    return new DateTime().now(DateTimeZone.forID(\"America / New_York\")).withDate(ld)",
-            "      .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "    return new DateTime().toDateTime(DateTimeZone.forID(\"America / New_York\"))",
+            "      .withDate(ld).toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
             "  }",
             "}")
         .doTest();
@@ -348,7 +348,7 @@ public class JodaTimeLocalTest {
             "class Test {",
             "  private DateTime badLocalDateUse() {",
             "    LocalDate ld = new LocalDate(2020, 6, 2);",
-            "    return new DateTime().now(DateTimeZone.getDefault()).withDate(ld)",
+            "    return new DateTime().toDateTime(DateTimeZone.getDefault()).withDate(ld)",
             "      .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
             "  }",
             "}")

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
@@ -33,7 +33,7 @@ public class JodaTimeLocalTest {
   }
 
   @Test
-  public void refactor() {
+  public void refactorLocalDateTime() {
     BugCheckerRefactoringTestHelper.newInstance(new JodaTimeLocal(), getClass())
         .addInputLines("Test.java",
             "import org.joda.time.DateTime;",
@@ -57,6 +57,96 @@ public class JodaTimeLocalTest {
                 + " ldt.getMinuteOfHour(), ldt.getSecondOfMinute(), ldt.getMillisOfSecond(),"
                 + " DateTimeZone.forID(\"America / New_York\"))",
             "    .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void refactorLocalDateTime2() {
+    BugCheckerRefactoringTestHelper.newInstance(new JodaTimeLocal(), getClass())
+        .addInputLines("Test.java",
+            "import org.joda.time.DateTime;",
+            "import org.joda.time.DateTimeZone;",
+            "import org.joda.time.LocalDateTime;",
+            "class Test {",
+            "  private DateTime badLocalDateTimeUse() {",
+            "    LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);",
+            "    return ldt.toDateTime()",
+            "      .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  }",
+            "}")
+        .addOutputLines("Test.java",
+            "import org.joda.time.DateTime;",
+            "import org.joda.time.DateTimeZone;",
+            "import org.joda.time.LocalDateTime;",
+            "class Test {",
+            "  private DateTime badLocalDateTimeUse() {",
+            "    LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);",
+            "    return new DateTime(ldt.getYear(), ldt.getMonthOfYear(), ldt.getDayOfYear(), ldt.getHourOfDay(),"
+                + " ldt.getMinuteOfHour(), ldt.getSecondOfMinute(), ldt.getMillisOfSecond(),"
+                + " DateTimeZone.getDefault())",
+            "      .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void refactorLocalTime() {
+    BugCheckerRefactoringTestHelper.newInstance(new JodaTimeLocal(), getClass())
+        .addInputLines("Test.java",
+            "import org.joda.time.DateTime;",
+            "import org.joda.time.DateTimeZone;",
+            "import org.joda.time.LocalTime;",
+            "class Test {",
+            "  private DateTime badLocalTimeUse() {",
+            "    LocalTime lt = new LocalTime(8, 0, 0, 0);",
+            "    return lt.toDateTimeToday(DateTimeZone.forID(\"America / New_York\"))",
+            "      .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  }",
+            "}")
+        .addOutputLines("Test.java",
+            "import org.joda.time.DateTime;",
+            "import org.joda.time.DateTimeZone;",
+            "import org.joda.time.LocalTime;",
+            "class Test {",
+            "  private DateTime badLocalTimeUse() {",
+            "    LocalTime lt = new LocalTime(8, 0, 0, 0);",
+            "    return new DateTime().now(DateTimeZone.forID(\"America / New_York\"))"
+                + ".withTime(lt.getHourOfDay(),"
+                + " lt.getMinuteOfHour(), lt.getSecondOfMinute(), lt.getMillisOfSecond())",
+            "      .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+
+  @Test
+  public void refactorLocalTime2() {
+    BugCheckerRefactoringTestHelper.newInstance(new JodaTimeLocal(), getClass())
+        .addInputLines("Test.java",
+            "import org.joda.time.DateTime;",
+            "import org.joda.time.DateTimeZone;",
+            "import org.joda.time.LocalTime;",
+            "class Test {",
+            "  private DateTime badLocalTimeUse() {",
+            "    LocalTime lt = new LocalTime(8, 0, 0, 0);",
+            "    return lt.toDateTimeToday()",
+            "      .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  }",
+            "}")
+        .addOutputLines("Test.java",
+            "import org.joda.time.DateTime;",
+            "import org.joda.time.DateTimeZone;",
+            "import org.joda.time.LocalTime;",
+            "class Test {",
+            "  private DateTime badLocalTimeUse() {",
+            "    LocalTime lt = new LocalTime(8, 0, 0, 0);",
+            "    return new DateTime().now(DateTimeZone.getDefault()).withTime(lt.getHourOfDay(),"
+                + " lt.getMinuteOfHour(), lt.getSecondOfMinute(), lt.getMillisOfSecond())",
+            "      .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
             "  }",
             "}")
         .doTest();

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
@@ -1,0 +1,35 @@
+package com.google.errorprone.xplat.checker;
+
+import com.google.errorprone.CompilationTestHelper;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link MyCustomCheck}.
+ */
+@RunWith(JUnit4.class)
+public class JodaTimeLocalTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setup() {
+    compilationHelper = CompilationTestHelper.newInstance(MyCustomCheck.class, getClass());
+  }
+
+  @Test
+  public void customCheckPositiveCases() {
+    compilationHelper.addSourceFile("JodaTimeLocalPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void customCheckNegativeCases() {
+    compilationHelper.addSourceFile("JodaTimeLocalNegativeCases.java").doTest();
+  }
+
+}
+

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
@@ -18,7 +18,7 @@ public class JodaTimeLocalTest {
 
   @Before
   public void setup() {
-    compilationHelper = CompilationTestHelper.newInstance(MyCustomCheck.class, getClass());
+    compilationHelper = CompilationTestHelper.newInstance(JodaTimeLocal.class, getClass());
   }
 
   @Test

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
@@ -1,5 +1,6 @@
 package com.google.errorprone.xplat.checker;
 
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 
 
@@ -22,13 +23,43 @@ public class JodaTimeLocalTest {
   }
 
   @Test
-  public void customCheckPositiveCases() {
+  public void positiveCases() {
     compilationHelper.addSourceFile("JodaTimeLocalPositiveCases.java").doTest();
   }
 
   @Test
-  public void customCheckNegativeCases() {
+  public void negativeCases() {
     compilationHelper.addSourceFile("JodaTimeLocalNegativeCases.java").doTest();
+  }
+
+  @Test
+  public void refactor() {
+    BugCheckerRefactoringTestHelper.newInstance(new JodaTimeLocal(), getClass())
+        .addInputLines("Test.java",
+            "import org.joda.time.DateTime;",
+            "import org.joda.time.DateTimeZone;",
+            "import org.joda.time.LocalDateTime;",
+            "class Test {",
+            "  private DateTime badLocalDateTimeUse() {",
+            "  LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);",
+            "  return ldt.toDateTime(DateTimeZone.forID(\"America / New_York\"))",
+            "    .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  }",
+            "}")
+        .addOutputLines("Test.java",
+            "import org.joda.time.DateTime;",
+            "import org.joda.time.DateTimeZone;",
+            "import org.joda.time.LocalDateTime;",
+            "class Test {",
+            "  private DateTime badLocalDateTimeUse() {",
+            "  LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);",
+            "return new DateTime(ldt.getYear(), ldt.getMonthOfYear(), ldt.getDayOfYear(), ldt.getHourOfDay(),"
+                + " ldt.getMinuteOfHour(), ldt.getSecondOfMinute(), ldt.getMillisOfSecond(),"
+                + " DateTimeZone.forID(\"America / New_York\"))",
+            "    .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  }",
+            "}")
+        .doTest();
   }
 
 }

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
@@ -1,0 +1,26 @@
+package com.google.errorprone.xplat.checker.testdata;
+
+import org.joda.time.LocalDateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+public class JodaTimeLocalNegativeCases {
+
+
+  // Create an 8 AM ET then convert it to PT.
+  private DateTime goodLocalDateTimeUse() {
+    LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);
+    return new DateTime(ldt.getYear(), ldt.getMonthOfYear(), ldt.getDayOfYear(), ldt.getHourOfDay(),
+        ldt.getMinuteOfHour(), ldt.getSecondOfMinute(), ldt.getMillisOfSecond(),
+        DateTimeZone.forID("America/New_York"))
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+
+  }
+
+  private void test() {
+    LocalDateTime test1 = new LocalDateTime(1L, DateTimeZone.forID("America/New_York"));
+  }
+
+}

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
@@ -9,7 +9,7 @@ import org.joda.time.DateTimeZone;
 public class JodaTimeLocalNegativeCases {
 
 
-  // Create an 8 AM ET then convert it to PT.
+  // LocalDateTime -> DateTime with DateTimeZone
   private DateTime goodLocalDateTimeUse() {
     LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);
     return new DateTime(ldt.getYear(), ldt.getMonthOfYear(), ldt.getDayOfYear(), ldt.getHourOfDay(),
@@ -19,6 +19,7 @@ public class JodaTimeLocalNegativeCases {
 
   }
 
+  // LocalDateTime -> DateTime without DateTimeZone
   private DateTime goodLocalDateTimeUse2() {
     LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);
     return new DateTime(ldt.getYear(), ldt.getMonthOfYear(), ldt.getDayOfYear(), ldt.getHourOfDay(),
@@ -28,22 +29,66 @@ public class JodaTimeLocalNegativeCases {
 
   }
 
+  // LocalTime -> DateTime with DateTimeZone
   private DateTime goodLocalTimeUse() {
     LocalTime lt = new LocalTime(8, 0, 0, 0);
     return new DateTime().now(DateTimeZone.forID("America/New_York"))
-        .withTime(lt.getHourOfDay(), lt.getMinuteOfHour(), lt.getSecondOfMinute(),
-            lt.getMillisOfSecond())
+        .withTime(lt)
         .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
   }
 
+  // LocalTime -> DateTime without DateTimeZone
   private DateTime goodLocalTimeUse2() {
     LocalTime lt = new LocalTime(8, 0, 0, 0);
     return new DateTime().now(DateTimeZone.getDefault())
-        .withTime(lt.getHourOfDay(), lt.getMinuteOfHour(), lt.getSecondOfMinute(),
-            lt.getMillisOfSecond())
+        .withTime(lt)
         .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
   }
 
+  // LocalDate -> DateTime with DateTimeZone
+  private DateTime goodLocalDateUse() {
+    LocalDate ld = new LocalDate(2020, 6, 2);
+    LocalTime now = LocalTime.now();
+    return new DateTime(ld.getYear(), ld.getMonthOfYear(), ld.getDayOfYear(), now.getHourOfDay(),
+        now.getMinuteOfHour(), now.getSecondOfMinute(), now.getMillisOfSecond(),
+        DateTimeZone.forID("America/New_York"))
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  // LocalDate -> DateTime without DateTimeZone
+  private DateTime goodLocalDateUse2() {
+    LocalDate ld = new LocalDate(2020, 6, 2);
+    LocalTime now = LocalTime.now();
+    return new DateTime(ld.getYear(), ld.getMonthOfYear(), ld.getDayOfYear(), now.getHourOfDay(),
+        now.getMinuteOfHour(), now.getSecondOfMinute(), now.getMillisOfSecond(),
+        DateTimeZone.getDefault())
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  // LocalDate -> DateTime with DateTimeZone - toDateTimeAtStartOfDay
+  private DateTime goodLocalDateUse3() {
+    LocalDate ld = new LocalDate(2020, 6, 2);
+    return ld.toDateTimeAtStartOfDay(DateTimeZone.forID("America/New_York"))
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  // LocalDate -> DateTime with DateTimeZone - toDateTimeAtCurrentTime
+  private DateTime goodLocalDateUse4() {
+    LocalDate ld = new LocalDate(2020, 6, 2);
+    return new DateTime().now(DateTimeZone.forID("America/New_York"))
+        .withDate(ld)
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  // LocalDate -> DateTime without DateTimeZone - toDateTimeAtCurrentTime
+  private DateTime goodLocalDateUse5() {
+    LocalDate ld = new LocalDate(2020, 6, 2);
+    return new DateTime().now(DateTimeZone.getDefault())
+        .withDate(ld)
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  // random constructor test
   private void consTest() {
     LocalDateTime test1 = new LocalDateTime(1L);
   }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
@@ -19,6 +19,31 @@ public class JodaTimeLocalNegativeCases {
 
   }
 
+  private DateTime goodLocalDateTimeUse2() {
+    LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);
+    return new DateTime(ldt.getYear(), ldt.getMonthOfYear(), ldt.getDayOfYear(), ldt.getHourOfDay(),
+        ldt.getMinuteOfHour(), ldt.getSecondOfMinute(), ldt.getMillisOfSecond(),
+        DateTimeZone.getDefault())
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+
+  }
+
+  private DateTime goodLocalTimeUse() {
+    LocalTime lt = new LocalTime(8, 0, 0, 0);
+    return new DateTime().now(DateTimeZone.forID("America/New_York"))
+        .withTime(lt.getHourOfDay(), lt.getMinuteOfHour(), lt.getSecondOfMinute(),
+            lt.getMillisOfSecond())
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  private DateTime goodLocalTimeUse2() {
+    LocalTime lt = new LocalTime(8, 0, 0, 0);
+    return new DateTime().now(DateTimeZone.getDefault())
+        .withTime(lt.getHourOfDay(), lt.getMinuteOfHour(), lt.getSecondOfMinute(),
+            lt.getMillisOfSecond())
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
   private void consTest() {
     LocalDateTime test1 = new LocalDateTime(1L);
   }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
@@ -19,8 +19,9 @@ public class JodaTimeLocalNegativeCases {
 
   }
 
-  private void test() {
-    LocalDateTime test1 = new LocalDateTime(1L, DateTimeZone.forID("America/New_York"));
+  private void consTest() {
+    LocalDateTime test1 = new LocalDateTime(1L);
   }
+
 
 }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker.testdata;
 
 import org.joda.time.LocalDateTime;

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalNegativeCases.java
@@ -46,7 +46,7 @@ public class JodaTimeLocalNegativeCases {
   // LocalTime -> DateTime with DateTimeZone
   private DateTime goodLocalTimeUse() {
     LocalTime lt = new LocalTime(8, 0, 0, 0);
-    return new DateTime().now(DateTimeZone.forID("America/New_York"))
+    return new DateTime().toDateTime(DateTimeZone.forID("America/New_York"))
         .withTime(lt)
         .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
   }
@@ -54,7 +54,7 @@ public class JodaTimeLocalNegativeCases {
   // LocalTime -> DateTime without DateTimeZone
   private DateTime goodLocalTimeUse2() {
     LocalTime lt = new LocalTime(8, 0, 0, 0);
-    return new DateTime().now(DateTimeZone.getDefault())
+    return new DateTime().toDateTime(DateTimeZone.getDefault())
         .withTime(lt)
         .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
   }
@@ -89,7 +89,7 @@ public class JodaTimeLocalNegativeCases {
   // LocalDate -> DateTime with DateTimeZone - toDateTimeAtCurrentTime
   private DateTime goodLocalDateUse4() {
     LocalDate ld = new LocalDate(2020, 6, 2);
-    return new DateTime().now(DateTimeZone.forID("America/New_York"))
+    return new DateTime().toDateTime(DateTimeZone.forID("America/New_York"))
         .withDate(ld)
         .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
   }
@@ -97,7 +97,7 @@ public class JodaTimeLocalNegativeCases {
   // LocalDate -> DateTime without DateTimeZone - toDateTimeAtCurrentTime
   private DateTime goodLocalDateUse5() {
     LocalDate ld = new LocalDate(2020, 6, 2);
-    return new DateTime().now(DateTimeZone.getDefault())
+    return new DateTime().toDateTime(DateTimeZone.getDefault())
         .withDate(ld)
         .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
   }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
@@ -18,17 +18,24 @@ public class JodaTimeLocalPositiveCases {
 
   private DateTime badLocalDateTimeUse2() {
     LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);
-    // xBUG: Diagnostic contains: The use of toDateTime()
+    // BUG: Diagnostic contains: The use of toDateTime()
     return ldt.toDateTime()
         .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
   }
 
-//  private DateTime badLocalTimeUse() {
-//    LocalTime lt = new LocalTime(8, 0, 0, 0);
-//    // xBUG: Diagnostic contains: The use of toDateTime(org.joda.time.DateTimeZone)
-//    return lt.toDateTime(DateTimeZone.forID("America/New_York"))
-//        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
-//  }
+  private DateTime badLocalTimeUse() {
+    LocalTime lt = new LocalTime(8, 0, 0, 0);
+    // BUG: Diagnostic contains: The use of toDateTimeToday(org.joda.time.DateTimeZone)
+    return lt.toDateTimeToday(DateTimeZone.forID("America/New_York"))
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  private DateTime badLocalTimeUse2() {
+    LocalTime lt = new LocalTime(8, 0, 0, 0);
+    // BUG: Diagnostic contains: The use of toDateTimeToday()
+    return lt.toDateTimeToday()
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
 
   private void consTest() {
     // BUG: Diagnostic contains: The use of LocalDateTime(org.joda.time.DateTimeZone)

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
@@ -16,16 +16,28 @@ public class JodaTimeLocalPositiveCases {
         .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
   }
 
-  private DateTime badLocalTimeUse() {
-    LocaTime lt = new LocalTime(8, 0, 0, 0);
-    // BUG: Diagnostic contains: The use of toDateTime(org.joda.time.DateTimeZone)
-    return ldt.toDateTime(DateTimeZone.forID("America/New_York"))
+  private DateTime badLocalDateTimeUse2() {
+    LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);
+    // xBUG: Diagnostic contains: The use of toDateTime()
+    return ldt.toDateTime()
         .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
   }
 
-  private void test() {
+//  private DateTime badLocalTimeUse() {
+//    LocalTime lt = new LocalTime(8, 0, 0, 0);
+//    // xBUG: Diagnostic contains: The use of toDateTime(org.joda.time.DateTimeZone)
+//    return lt.toDateTime(DateTimeZone.forID("America/New_York"))
+//        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+//  }
+
+  private void consTest() {
     // BUG: Diagnostic contains: The use of LocalDateTime(org.joda.time.DateTimeZone)
     LocalDateTime test1 = new LocalDateTime(DateTimeZone.forID("America/New_York"));
 
+    // BUG: Diagnostic contains: The use of LocalDateTime(long,org.joda.time.DateTimeZone)
+    LocalDateTime test2 = new LocalDateTime(1L, DateTimeZone.forID("America/New_York"));
+
+    // BUG: Diagnostic contains: The use of LocalDateTime(java.lang.Object,org.joda.time.DateTimeZone)
+    LocalDateTime test3 = new LocalDateTime(null, DateTimeZone.forID("America/New_York"));
   }
 }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
@@ -1,0 +1,24 @@
+package com.google.errorprone.xplat.checker.testdata;
+
+import org.joda.time.LocalDateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+public class JodaTimeLocalPositiveCases {
+
+
+  private DateTime badLocalDateTimeUse() {
+    LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);
+    // BUG: Diagnostic contains: The use of toDateTime(org.joda.time.DateTimeZone)
+    return ldt.toDateTime(DateTimeZone.forID("America/New_York"))
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  private void test() {
+    // BUG: Diagnostic contains: The use of LocalDateTime(org.joda.time.DateTimeZone)
+    LocalDateTime test1 = new LocalDateTime(DateTimeZone.forID("America/New_York"));
+
+  }
+}

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
@@ -37,6 +37,43 @@ public class JodaTimeLocalPositiveCases {
         .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
   }
 
+  private DateTime badLocalDateUse() {
+    LocalDate ld = new LocalDate(2020, 6, 2);
+    LocalTime now = LocalTime.now();
+    // BUG: Diagnostic contains: The use of toDateTime(org.joda.time.LocalTime,org.joda.time.DateTimeZone)
+    return ld.toDateTime(now, DateTimeZone.forID("America/New_York"))
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  private DateTime badLocalDateUse2() {
+    LocalDate ld = new LocalDate(2020, 6, 2);
+    LocalTime now = LocalTime.now();
+    // BUG: Diagnostic contains: The use of toDateTime(org.joda.time.LocalTime)
+    return ld.toDateTime(now)
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  private DateTime badLocalDateUse3() {
+    LocalDate ld = new LocalDate(2020, 6, 2);
+    // BUG: Diagnostic contains: The use of toDateTimeAtStartOfDay()
+    return ld.toDateTimeAtStartOfDay()
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  private DateTime badLocalDateUse4() {
+    LocalDate ld = new LocalDate(2020, 6, 2);
+    // BUG: Diagnostic contains: The use of toDateTimeAtCurrentTime(org.joda.time.DateTimeZone)
+    return ld.toDateTimeAtCurrentTime(DateTimeZone.forID("America/New_York"))
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
+  private DateTime badLocalDateUse5() {
+    LocalDate ld = new LocalDate(2020, 6, 2);
+    // BUG: Diagnostic contains: The use of toDateTimeAtCurrentTime()
+    return ld.toDateTimeAtCurrentTime()
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
   private void consTest() {
     // BUG: Diagnostic contains: The use of LocalDateTime(org.joda.time.DateTimeZone)
     LocalDateTime test1 = new LocalDateTime(DateTimeZone.forID("America/New_York"));

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker.testdata;
 
 import org.joda.time.LocalDateTime;

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeLocalPositiveCases.java
@@ -16,6 +16,13 @@ public class JodaTimeLocalPositiveCases {
         .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
   }
 
+  private DateTime badLocalTimeUse() {
+    LocaTime lt = new LocalTime(8, 0, 0, 0);
+    // BUG: Diagnostic contains: The use of toDateTime(org.joda.time.DateTimeZone)
+    return ldt.toDateTime(DateTimeZone.forID("America/New_York"))
+        .toDateTime(DateTimeZone.forID("America/Los_Angeles"));
+  }
+
   private void test() {
     // BUG: Diagnostic contains: The use of LocalDateTime(org.joda.time.DateTimeZone)
     LocalDateTime test1 = new LocalDateTime(DateTimeZone.forID("America/New_York"));


### PR DESCRIPTION
A checker that bans the use of some unsupported Joda-Time Local methods and constructors.

All variations of the `LocalDateTime` constructor that take a `DateTimeZone` are banned.

Several methods are banned, and all of these have suggested fixes:
- `LocalDateTime toDateTime()`
- `LocalDateTime toDateTime(DateTimeZone)`
- `LocalTime toDateTimeToday()`
- `LocalTime toDateTimeToday(DateTimeZone)`
- `LocalDate toDateTime(LocalTime)`
- `LocalDate toDateTime(LocalTime, DateTimeZone)`
- `LocalDate toDateTimeAtStartOfDay()`
- `LocalDate toDateTimeAtCurrentTime()`
- `LocalDate toDateTimeAtCurrentTime(DateTimeZone)`


