### PR TITLE
Add Apache license headers.

### DIFF
--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/AllowLegacyTime.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/AllowLegacyTime.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker;
 
 import static java.lang.annotation.ElementType.CONSTRUCTOR;

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeClassBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeClassBan.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBan.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/LegacyTimeBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/LegacyTimeBan.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/CustomCheckTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/CustomCheckTest.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker;
 
 import com.google.errorprone.CompilationTestHelper;

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeClassBanTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeClassBanTest.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker;
 
 import com.google.common.base.Predicates;

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBanTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBanTest.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker;
 
 import com.google.errorprone.CompilationTestHelper;

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/LegacyTimeBanTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/LegacyTimeBanTest.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker;
 
 import com.google.errorprone.CompilationTestHelper;

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CustomCheckNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CustomCheckNegativeCases.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker.testdata;
 
 import java.util.Arrays;

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CustomCheckPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/CustomCheckPositiveCases.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker.testdata;
 
 import java.util.Arrays;

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanNegativeCases.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker.testdata;
 
 

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeClassBanPositiveCases.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker.testdata;
 
 import org.joda.time.DateTime;

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeObjectParamNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeObjectParamNegativeCases.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker.testdata;
 
 import java.util.Date;

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeObjectParamPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/JodaTimeObjectParamPositiveCases.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker.testdata;
 
 import org.joda.time.DateTime;

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/LegacyTimeBanNegativeCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/LegacyTimeBanNegativeCases.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker.testdata;
 
 import com.google.errorprone.xplat.checker.AllowLegacyTime;

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/LegacyTimeBanPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/LegacyTimeBanPositiveCases.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.errorprone.xplat.checker.testdata;
 
 import com.google.errorprone.xplat.checker.AllowLegacyTime;


### PR DESCRIPTION
Files from the Error Prone sample code are skipped since they already
have the headers.
