### PR TITLE
UnnecessaryConcurrentHashMap checker

### DIFF
--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
@@ -1,0 +1,69 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.errorprone.xplat.checker;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.AssignmentTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import java.beans.Expression;
+import java.util.concurrent.ConcurrentHashMap;
+
+@BugPattern(
+    name = "UnnecessaryConcurrentHashMap",
+    summary = "Suggests the use of synchronizedMap instead of ConcurrentHashMap",
+    explanation =
+        "ConcurrentHashMap is not well suited for use on Android devices. For this reason,"
+            + " synchronizedMap is suggested to be used in its place for better compatibility.",
+    severity = WARNING)
+public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClassTreeMatcher,
+    VariableTreeMatcher {
+
+  private static final Matcher<Tree> MATCHER =
+      Matchers.isSameType("java.util.concurrent.ConcurrentHashMap");
+
+  @Override
+  public Description matchNewClass(NewClassTree tree, VisitorState state) {
+    if (MATCHER.matches(tree, state)) {
+      System.out.println(ASTHelpers.getType(tree));
+      System.out.println();
+    }
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    if (MATCHER.matches(tree, state)) {
+      System.out.println(ASTHelpers.getType(tree).getTypeArguments());
+      System.out.println(state.getSourceForNode(tree));
+      System.out.println();
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
@@ -55,16 +55,16 @@ public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClass
           Matchers.not(Matchers.isSameType("java.util.concurrent.ConcurrentHashMap"))
       );
 
-  private static final Set<NewClassTree> seenConstructors = new HashSet<>();
 
   @Override
   public Description matchNewClass(NewClassTree tree, VisitorState state) {
-    if (MATCHER.matches(tree, state) && !seenConstructors.contains(tree)) {
+    if (MATCHER.matches(tree, state)) {
 
       Tree variable = state.getPath().getParentPath().getLeaf();
 
       SuggestedFix.Builder fix = SuggestedFix.builder()
           .addImport("java.util.Collections")
+          .addImport("java.util.HashMap")
           .replace(
               ((JCTree) tree).getStartPosition(),
               state.getEndPosition(tree),
@@ -105,17 +105,19 @@ public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClass
               }
             }.scan(state.getPath().getParentPath().getParentPath().getParentPath(), null);
 
+        System.out.println(origin);
+
         if (origin != null && OTHER_MAP_INTERFACE_MATCHER.matches(origin, state)) {
+
           String originSource = state.getSourceForNode(origin);
-          fix2.setShortDescription("Hello can you hear me?")
-              .addImport("java.util.Map")
+          fix2.addImport("java.util.Map")
               .replace(
                   ((JCTree) origin).getStartPosition(),
                   ((JCTree) origin).getStartPosition() + originSource.indexOf("<"),
                   "Map");
         }
       }
-      
+
       return buildDescription(tree)
           .setMessage("ConcurrentHashMap is not advised for cross platform use. Use"
               + " Collections.synchronizedMap instead.")
@@ -153,4 +155,6 @@ public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClass
 
     return Description.NO_MATCH;
   }
+
+
 }

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
@@ -30,8 +30,12 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.tree.JCTree;
 import java.beans.Expression;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -51,8 +55,23 @@ public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClass
   @Override
   public Description matchNewClass(NewClassTree tree, VisitorState state) {
     if (MATCHER.matches(tree, state)) {
+      System.out.println("new");
       System.out.println(ASTHelpers.getType(tree));
+      System.out.println(state.getPath().getParentPath().getLeaf());
+      System.out.println(ASTHelpers.getSymbol(state.getPath().getParentPath().getLeaf()));
+
+      VariableTree var =
+          new TreePathScanner<VariableTree, Void>() {
+
+            @Override
+            public VariableTree visitVariable(VariableTree node, Void unused) {
+
+              return super.visitVariable(node, null);
+            }
+          }.scan(state.getPath().getParentPath(), null);
+      System.out.println(var);
       System.out.println();
+
     }
     return Description.NO_MATCH;
   }
@@ -60,8 +79,46 @@ public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClass
   @Override
   public Description matchVariable(VariableTree tree, VisitorState state) {
     if (MATCHER.matches(tree, state)) {
+      System.out.println("var");
       System.out.println(ASTHelpers.getType(tree).getTypeArguments());
       System.out.println(state.getSourceForNode(tree));
+      System.out.println(state.getSourceForNode(tree).contains("="));
+
+      Symbol symbol = ASTHelpers.getSymbol(tree);
+      Tree declarationParent = state.getPath().getParentPath().getLeaf();
+
+      NewClassTree newClass =
+          new TreePathScanner<NewClassTree, Void>() {
+            @Override
+            public NewClassTree visitNewClass(NewClassTree node, Void unused) {
+
+              if (node != null) {
+                return node;
+              }
+
+              return super.visitNewClass(node, unused);
+            }
+          }.scan(state.getPath(), null);
+
+      System.out.println(newClass);
+
+      AssignmentTree assignment =
+          new TreePathScanner<AssignmentTree, Void>() {
+
+            @Override
+            public AssignmentTree visitAssignment(AssignmentTree node, Void unused) {
+              if (symbol.equals(ASTHelpers.getSymbol(node.getVariable()))) {
+                Tree grandParent = getCurrentPath().getParentPath().getParentPath().getLeaf();
+                if (getCurrentPath().getParentPath().getLeaf() instanceof StatementTree
+                    && grandParent.equals(declarationParent)) {
+                  return node;
+                }
+              }
+              return super.visitAssignment(node, null);
+            }
+          }.scan(state.getPath().getParentPath(), null);
+
+      System.out.println(assignment);
       System.out.println();
     }
     return Description.NO_MATCH;

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
@@ -38,13 +38,13 @@ import java.util.Optional;
 
 /**
  * Checks for usage of ConcurrentHashMap and suggests the use of Collections.synchronizedMap.
- * ConcurrentHashMap is not well supported on at least one available platform.
+ * ConcurrentHashMap is not well supported on iOS.
  */
 @BugPattern(
     name = "UnnecessaryConcurrentHashMap",
     summary = "Suggests the use of Collections.synchronizedMap instead of ConcurrentHashMap.",
     explanation =
-        "ConcurrentHashMap is not well supported on at least one available platform."
+        "ConcurrentHashMap is not well supported on iOS."
             + " For this reason, Collections.synchronizedMap is suggested to be used"
             + " in its place for better cross-platform compatibility.",
     severity = WARNING)
@@ -64,7 +64,7 @@ public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClass
       );
 
   private static final String STANDARD_MESSAGE =
-      "ConcurrentHashMap is not advised for cross platform use. Use"
+      "ConcurrentHashMap is not well supported on iOS. Use"
           + " Collections.synchronizedMap instead.";
 
   private Description standardDescription(Tree tree, SuggestedFix fix, String message) {
@@ -164,7 +164,8 @@ public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClass
 
       return Optional.of(buildDescription(origin)
           .setMessage("This variable is declared with an interface that is not compatible"
-              + " with Collections.synchronizedMap, which is advised over ConcurrentHashMap.")
+              + " with Collections.synchronizedMap, which is suggested to be used"
+              + " in the previous warning.")
           .addFix(SuggestedFix.builder()
               .addImport("java.util.Map")
               .replace(

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
@@ -37,16 +37,16 @@ import com.sun.tools.javac.tree.JCTree;
 import java.util.Optional;
 
 /**
- * Checks for usage of ConcurrentHashMap and suggests the use of Collections.synchronizedMap. This
- * is due to how ConcurrentHashMap behaves on Android.
+ * Checks for usage of ConcurrentHashMap and suggests the use of Collections.synchronizedMap.
+ * ConcurrentHashMap is not well supported on at least one available platform.
  */
 @BugPattern(
     name = "UnnecessaryConcurrentHashMap",
     summary = "Suggests the use of Collections.synchronizedMap instead of ConcurrentHashMap.",
     explanation =
-        "ConcurrentHashMap is not well suited for use on Android devices. For this reason,"
-            + " Collections.synchronizedMap is suggested to be used in its place for"
-            + " better compatibility.",
+        "ConcurrentHashMap is not well supported on at least one available platform."
+            + " For this reason, Collections.synchronizedMap is suggested to be used"
+            + " in its place for better cross-platform compatibility.",
     severity = WARNING)
 public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClassTreeMatcher,
     VariableTreeMatcher {

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
@@ -14,32 +14,27 @@
 
 package com.google.errorprone.xplat.checker;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
-import com.google.errorprone.bugpatterns.BugChecker.AssignmentTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
-import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.util.ASTHelpers;
-import com.sun.source.tree.AssignmentTree;
-import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.NewClassTree;
-import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePathScanner;
-import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.tree.JCTree;
-import java.beans.Expression;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 @BugPattern(
     name = "UnnecessaryConcurrentHashMap",
@@ -54,100 +49,108 @@ public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClass
   private static final Matcher<Tree> MATCHER =
       Matchers.isSameType("java.util.concurrent.ConcurrentHashMap");
 
+  private static final Matcher<Tree> OTHER_MAP_INTERFACE_MATCHER =
+      Matchers.allOf(
+          Matchers.not(Matchers.isSameType("java.util.Map")),
+          Matchers.not(Matchers.isSameType("java.util.concurrent.ConcurrentHashMap"))
+      );
+
+  private static final Set<NewClassTree> seenConstructors = new HashSet<>();
+
   @Override
   public Description matchNewClass(NewClassTree tree, VisitorState state) {
-    if (MATCHER.matches(tree, state)) {
-      System.out.println("new");
-      System.out.println(ASTHelpers.getType(tree));
-      System.out.println(state.getPath().getParentPath().getLeaf());
-      System.out.println(ASTHelpers.getSymbol(state.getPath().getParentPath().getLeaf()));
+    if (MATCHER.matches(tree, state) && !seenConstructors.contains(tree)) {
 
-      VariableTree var =
-          new TreePathScanner<VariableTree, Void>() {
-
-            @Override
-            public VariableTree visitVariable(VariableTree node, Void unused) {
-              if (node != null) {
-                return node;
-              }
-
-              return super.visitVariable(node, null);
-            }
-          }.scan(state.getPath().getParentPath(), null);
-      System.out.println(var);
-      System.out.println();
-
-      return buildDescription(tree)
-          .setMessage("2 2 2ConcurrentHashMap is not advised for cross platform use.")
-          .build();
-
-    }
-
-    return Description.NO_MATCH;
-  }
-
-  @Override
-  public Description matchVariable(VariableTree tree, VisitorState state) {
-    if (MATCHER.matches(tree, state)) {
-//      System.out.println("var");
-//      System.out.println(ASTHelpers.getType(tree).getTypeArguments());
-//      System.out.println(state.getSourceForNode(tree));
-//      System.out.println(state.getSourceForNode(tree).contains("="));
-
-//      Symbol symbol = ASTHelpers.getSymbol(tree);
-//      Tree declarationParent = state.getPath().getParentPath().getLeaf();
-
-      NewClassTree newClass =
-          new TreePathScanner<NewClassTree, Void>() {
-            @Override
-            public NewClassTree visitNewClass(NewClassTree node, Void unused) {
-
-              if (node != null) {
-                return node;
-              }
-
-              return super.visitNewClass(node, unused);
-            }
-          }.scan(state.getPath(), null);
-
-      System.out.println(newClass);
+      Tree variable = state.getPath().getParentPath().getLeaf();
 
       SuggestedFix.Builder fix = SuggestedFix.builder()
-          .addImport("java.util.Map")
           .addImport("java.util.Collections")
           .replace(
               ((JCTree) tree).getStartPosition(),
-              ((JCTree) tree).getStartPosition() + 14,
-              "");
+              state.getEndPosition(tree),
+              "Collections.synchronizedMap(new HashMap<>())");
 
-      if (newClass != null) {
-        fix.replace(
-            ((JCTree) newClass).getStartPosition(),
-            state.getEndPosition(newClass),
-            "Collections.synchronizedMap(new HashMap<>())"
-        );
+      SuggestedFix.Builder fix2 = SuggestedFix.builder();
+
+      if (variable != null && variable.getKind() == Kind.VARIABLE) {
+        String source = state.getSourceForNode(variable);
+
+        if (source != null && source.contains("<")) {
+          fix.addImport("java.util.Map");
+          fix.replace(
+              ((JCTree) variable).getStartPosition(),
+              ((JCTree) variable).getStartPosition() + source.indexOf("<"),
+              "Map");
+        }
+
+      } else if (variable != null && variable.getKind() == Kind.ASSIGNMENT) {
+        String originName = state.getSourceForNode(state.getPath().getParentPath().getLeaf())
+            .substring(0,
+                state.getSourceForNode(state.getPath().getParentPath().getLeaf()).indexOf("="))
+            .trim();
+
+        VariableTree origin =
+            new TreePathScanner<VariableTree, Void>() {
+              @Override
+              public VariableTree reduce(VariableTree a, VariableTree b) {
+                return a == null ? b : a;
+              }
+
+              @Override
+              public VariableTree visitVariable(VariableTree node, Void aVoid) {
+                if (node.getName().toString().equals(originName)) {
+                  return node;
+                }
+                return super.visitVariable(node, aVoid);
+              }
+            }.scan(state.getPath().getParentPath().getParentPath().getParentPath(), null);
+
+        if (origin != null && OTHER_MAP_INTERFACE_MATCHER.matches(origin, state)) {
+          String originSource = state.getSourceForNode(origin);
+          fix2.setShortDescription("Hello can you hear me?")
+              .addImport("java.util.Map")
+              .replace(
+                  ((JCTree) origin).getStartPosition(),
+                  ((JCTree) origin).getStartPosition() + originSource.indexOf("<"),
+                  "Map");
+        }
       }
-
+      
       return buildDescription(tree)
-          .setMessage("ConcurrentHashMap is not advised for cross platform use.")
+          .setMessage("ConcurrentHashMap is not advised for cross platform use. Use"
+              + " Collections.synchronizedMap instead.")
           .addFix(fix.build())
           .build();
 
-//
-//      AssignmentTree assignment =
-//          new TreePathScanner<AssignmentTree, Void>() {
-//
-//            @Override
-//            public AssignmentTree visitAssignment(AssignmentTree node, Void unused) {
-//              if (symbol.equals(ASTHelpers.getSymbol(node.getVariable()))) {
-//                return node;
-//              }
-//              return super.visitAssignment(node, null);
-//            }
-//          }.scan(state.getPath().getParentPath(), null);
-//
-//      System.out.println(assignment);
+
     }
+    return Description.NO_MATCH;
+  }
+
+  /**
+   * This matcher only matches on variables that are declared with type ConcurrentHashMap and are
+   * not assigned a value on the same line. An example would be {@code ConcurrentHashMap<String,
+   * Integer> map;}
+   */
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+
+    String source = state.getSourceForNode(tree);
+    if (source != null && !source.contains("=") && MATCHER.matches(tree, state)) {
+
+      return buildDescription(tree)
+          .setMessage("ConcurrentHashMap is not advised for cross platform use. Use"
+              + " Collections.synchronizedMap instead.")
+          .addFix(
+              SuggestedFix.builder()
+                  .addImport("java.util.Map")
+                  .replace(
+                      ((JCTree) tree).getStartPosition(),
+                      ((JCTree) tree).getStartPosition() + 14,
+                      "").build())
+          .build();
+    }
+
     return Description.NO_MATCH;
   }
 }

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMap.java
@@ -23,6 +23,7 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
@@ -70,8 +71,6 @@ public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClass
               state.getEndPosition(tree),
               "Collections.synchronizedMap(new HashMap<>())");
 
-      SuggestedFix.Builder fix2 = SuggestedFix.builder();
-
       if (variable != null && variable.getKind() == Kind.VARIABLE) {
         String source = state.getSourceForNode(variable);
 
@@ -110,7 +109,7 @@ public class UnnecessaryConcurrentHashMap extends BugChecker implements NewClass
         if (origin != null && OTHER_MAP_INTERFACE_MATCHER.matches(origin, state)) {
 
           String originSource = state.getSourceForNode(origin);
-          fix2.addImport("java.util.Map")
+          fix.addImport("java.util.Map")
               .replace(
                   ((JCTree) origin).getStartPosition(),
                   ((JCTree) origin).getStartPosition() + originSource.indexOf("<"),

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Unit tests for {@link MyCustomCheck}.
+ * Unit tests for {@link UnnecessaryConcurrentHashMap}.
  */
 @RunWith(JUnit4.class)
 public class UnnecessaryConcurrentHashMapTest {
@@ -69,6 +69,31 @@ public class UnnecessaryConcurrentHashMapTest {
   }
 
   @Test
+  public void refactorSameLineConcurrentMap() {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryConcurrentHashMap(), getClass())
+        .addInputLines("Test.java",
+            "import java.util.concurrent.ConcurrentMap;",
+            "import java.util.concurrent.ConcurrentHashMap;",
+            "class Test {",
+            "  private void test() {",
+            "    ConcurrentMap<String, Integer> map = new ConcurrentHashMap<String, Integer>();",
+            "  }",
+            "}")
+        .addOutputLines("Test.java",
+            "import java.util.Collections;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "import java.util.concurrent.ConcurrentHashMap;",
+            "import java.util.concurrent.ConcurrentMap;",
+            "class Test {",
+            "  private void test() {",
+            "    Map<String, Integer> map = Collections.synchronizedMap(new HashMap<>());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void refactorDeclaration() {
     BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryConcurrentHashMap(), getClass())
         .addInputLines("Test.java",
@@ -91,6 +116,33 @@ public class UnnecessaryConcurrentHashMapTest {
 
   @Test
   public void refactor2Lines() {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryConcurrentHashMap(), getClass())
+        .addInputLines("Test.java",
+            "import java.util.concurrent.ConcurrentHashMap;",
+            "class Test {",
+            "  private void test() {",
+            "    ConcurrentHashMap<String, Integer> map;",
+            "    int x = 1;",
+            "    map = new ConcurrentHashMap<>();",
+            "  }",
+            "}")
+        .addOutputLines("Test.java",
+            "import java.util.Collections;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "import java.util.concurrent.ConcurrentHashMap;",
+            "class Test {",
+            "  private void test() {",
+            "    Map<String, Integer> map;",
+            "    int x = 1;",
+            "    map = Collections.synchronizedMap(new HashMap<>());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void refactorIncompatibleInterface() {
     BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryConcurrentHashMap(), getClass())
         .addInputLines("Test.java",
             "import java.util.concurrent.ConcurrentMap;",

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
@@ -89,4 +89,33 @@ public class UnnecessaryConcurrentHashMapTest {
         .doTest();
   }
 
+  @Test
+  public void refactor2Lines() {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryConcurrentHashMap(), getClass())
+        .addInputLines("Test.java",
+            "import java.util.concurrent.ConcurrentMap;",
+            "import java.util.concurrent.ConcurrentHashMap;",
+            "class Test {",
+            "  private void test() {",
+            "    ConcurrentMap<String, Integer> map;",
+            "    int x = 1;",
+            "    map = new ConcurrentHashMap<>();",
+            "  }",
+            "}")
+        .addOutputLines("Test.java",
+            "import java.util.Collections;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "import java.util.concurrent.ConcurrentHashMap;",
+            "import java.util.concurrent.ConcurrentMap;",
+            "class Test {",
+            "  private void test() {",
+            "    Map<String, Integer> map;",
+            "    int x = 1;",
+            "    map = Collections.synchronizedMap(new HashMap<>());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
 }

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
@@ -46,31 +46,44 @@ public class UnnecessaryConcurrentHashMapTest {
   }
 
   @Test
-  public void refactor() {
-    BugCheckerRefactoringTestHelper.newInstance(new JodaTimeLocal(), getClass())
+  public void refactorSameLine() {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryConcurrentHashMap(), getClass())
         .addInputLines("Test.java",
-            "import org.joda.time.DateTime;",
-            "import org.joda.time.DateTimeZone;",
-            "import org.joda.time.LocalDateTime;",
+            "import java.util.concurrent.ConcurrentHashMap;",
             "class Test {",
-            "  private DateTime badLocalDateTimeUse() {",
-            "  LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);",
-            "  return ldt.toDateTime(DateTimeZone.forID(\"America / New_York\"))",
-            "    .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  private void test() {",
+            "    ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<String, Integer>();",
             "  }",
             "}")
         .addOutputLines("Test.java",
-            "import org.joda.time.DateTime;",
-            "import org.joda.time.DateTimeZone;",
-            "import org.joda.time.LocalDateTime;",
+            "import java.util.Collections;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "import java.util.concurrent.ConcurrentHashMap;",
             "class Test {",
-            "  private DateTime badLocalDateTimeUse() {",
-            "  LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);",
-            "return new DateTime(ldt.getYear(), ldt.getMonthOfYear(), ldt.getDayOfYear(),"
-                + " ldt.getHourOfDay(),"
-                + " ldt.getMinuteOfHour(), ldt.getSecondOfMinute(), ldt.getMillisOfSecond(),"
-                + " DateTimeZone.forID(\"America / New_York\"))",
-            "    .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  private void test() {",
+            "    Map<String, Integer> map = Collections.synchronizedMap(new HashMap<>());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void refactorDeclaration() {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryConcurrentHashMap(), getClass())
+        .addInputLines("Test.java",
+            "import java.util.concurrent.ConcurrentHashMap;",
+            "class Test {",
+            "  private void test() {",
+            "    ConcurrentHashMap<String, Integer> map;",
+            "  }",
+            "}")
+        .addOutputLines("Test.java",
+            "import java.util.Map;",
+            "import java.util.concurrent.ConcurrentHashMap;",
+            "class Test {",
+            "  private void test() {",
+            "    Map<String, Integer> map;",
             "  }",
             "}")
         .doTest();

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
@@ -69,6 +69,30 @@ public class UnnecessaryConcurrentHashMapTest {
   }
 
   @Test
+  public void refactorSameLineMap() {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryConcurrentHashMap(), getClass())
+        .addInputLines("Test.java",
+            "import java.util.concurrent.ConcurrentHashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  private void test() {",
+            "    Map<String, Integer> map = new ConcurrentHashMap<>();",
+            "  }",
+            "}")
+        .addOutputLines("Test.java",
+            "import java.util.Collections;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "import java.util.concurrent.ConcurrentHashMap;",
+            "class Test {",
+            "  private void test() {",
+            "    Map<String, Integer> map = Collections.synchronizedMap(new HashMap<>());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void refactorSameLineConcurrentMap() {
     BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryConcurrentHashMap(), getClass())
         .addInputLines("Test.java",

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
@@ -1,0 +1,47 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.errorprone.xplat.checker;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link MyCustomCheck}.
+ */
+@RunWith(JUnit4.class)
+public class UnnecessaryConcurrentHashMapTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setup() {
+    compilationHelper = CompilationTestHelper
+        .newInstance(UnnecessaryConcurrentHashMap.class, getClass());
+  }
+
+  @Test
+  public void positiveCases() {
+    compilationHelper.addSourceFile("UnnecessaryConcurrentHashMapTestPositive.java").doTest();
+  }
+
+  @Test
+  public void negativeCases() {
+    compilationHelper.addSourceFile("UnnecessaryConcurrentHashMapTestNegative.java").doTest();
+  }
+
+}

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/UnnecessaryConcurrentHashMapTest.java
@@ -14,6 +14,7 @@
 
 package com.google.errorprone.xplat.checker;
 
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +43,37 @@ public class UnnecessaryConcurrentHashMapTest {
   @Test
   public void negativeCases() {
     compilationHelper.addSourceFile("UnnecessaryConcurrentHashMapTestNegative.java").doTest();
+  }
+
+  @Test
+  public void refactor() {
+    BugCheckerRefactoringTestHelper.newInstance(new JodaTimeLocal(), getClass())
+        .addInputLines("Test.java",
+            "import org.joda.time.DateTime;",
+            "import org.joda.time.DateTimeZone;",
+            "import org.joda.time.LocalDateTime;",
+            "class Test {",
+            "  private DateTime badLocalDateTimeUse() {",
+            "  LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);",
+            "  return ldt.toDateTime(DateTimeZone.forID(\"America / New_York\"))",
+            "    .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  }",
+            "}")
+        .addOutputLines("Test.java",
+            "import org.joda.time.DateTime;",
+            "import org.joda.time.DateTimeZone;",
+            "import org.joda.time.LocalDateTime;",
+            "class Test {",
+            "  private DateTime badLocalDateTimeUse() {",
+            "  LocalDateTime ldt = new LocalDateTime(2020, 6, 2, 8, 0, 0, 0);",
+            "return new DateTime(ldt.getYear(), ldt.getMonthOfYear(), ldt.getDayOfYear(),"
+                + " ldt.getHourOfDay(),"
+                + " ldt.getMinuteOfHour(), ldt.getSecondOfMinute(), ldt.getMillisOfSecond(),"
+                + " DateTimeZone.forID(\"America / New_York\"))",
+            "    .toDateTime(DateTimeZone.forID(\"America / Los_Angeles\"));",
+            "  }",
+            "}")
+        .doTest();
   }
 
 }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestNegative.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestNegative.java
@@ -18,12 +18,17 @@ package com.google.errorprone.xplat.checker.testdata;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 
 public class UnnecessaryConcurrentHashMapTestNegative {
 
   public void test() {
     Map<String, Integer> map = Collections.synchronizedMap(new HashMap<>());
-    
+
+    Map<String, Integer> map2 = Collections.synchronizedMap(new HashMap<>());
+
     Map<String, Integer> map3;
+
+    ConcurrentMap<Object, String> map4;
   }
 }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestNegative.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestNegative.java
@@ -22,10 +22,11 @@ import java.util.concurrent.ConcurrentMap;
 
 public class UnnecessaryConcurrentHashMapTestNegative {
 
+  // All of these are allowed map usages
   public void test() {
     Map<String, Integer> map = Collections.synchronizedMap(new HashMap<>());
 
-    Map<String, Integer> map2 = Collections.synchronizedMap(new HashMap<>());
+    Map<Long, String> map2 = Collections.synchronizedMap(new HashMap<>());
 
     Map<String, Integer> map3;
 

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestNegative.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestNegative.java
@@ -1,0 +1,29 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.errorprone.xplat.checker.testdata;
+
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class UnnecessaryConcurrentHashMapTestNegative {
+
+  public void test() {
+    Map<String, Integer> map = Collections.synchronizedMap(new HashMap<>());
+    
+    Map<String, Integer> map3;
+  }
+}

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
@@ -21,27 +21,42 @@ import java.util.concurrent.ConcurrentMap;
 public class UnnecessaryConcurrentHashMapTestPositive {
 
   public void test() {
+    // Tests declaration and new class on same line
     // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<String, Integer>();
 
+    // Tests declaration and new class on same line with implicit type vars
     // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     ConcurrentHashMap<Object, Long> map2 = new ConcurrentHashMap<>();
 
+    // Tests declaration alone
     // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     ConcurrentHashMap<String, Integer> map3;
 
+    // Tests new class alone
     // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     map3 = new ConcurrentHashMap<String, Integer>();
 
+    // Tests special case - incompatable interface with variable that is instantiated later
+    // BUG: Diagnostic contains: This variable is declared with an interface
     ConcurrentMap<Object, String> map4;
 
+    // Tests declaration with invalid interface on same line as new class
     // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     ConcurrentMap<String, Integer> map5 = new ConcurrentHashMap<>();
 
+    // Tests declaration with valid interface on same line as new class
     // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     Map<String, Integer> map6 = new ConcurrentHashMap<>();
 
+    // Tests special case - incompatable interface with variable that is instantiated later
     // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     map4 = new ConcurrentHashMap<>();
+
+    if (true) {
+      // Tests special case - variable declaration not in same scope
+      // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+      map4 = new ConcurrentHashMap<>();
+    }
   }
 }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
@@ -41,7 +41,7 @@ public class UnnecessaryConcurrentHashMapTestPositive {
     // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     Map<String, Integer> map6 = new ConcurrentHashMap<>();
 
-    // xBUG: Diagnostic contains: ConcurrentHashMap is not advised
+    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     map4 = new ConcurrentHashMap<>();
   }
 }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
@@ -22,19 +22,19 @@ public class UnnecessaryConcurrentHashMapTestPositive {
 
   public void test() {
     // Tests declaration and new class on same line
-    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+    // BUG: Diagnostic contains: ConcurrentHashMap is not well supported on iOS
     ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<String, Integer>();
 
     // Tests declaration and new class on same line with implicit type vars
-    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+    // BUG: Diagnostic contains: ConcurrentHashMap is not well supported on iOS
     ConcurrentHashMap<Object, Long> map2 = new ConcurrentHashMap<>();
 
     // Tests declaration alone
-    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+    // BUG: Diagnostic contains: ConcurrentHashMap is not well supported on iOS
     ConcurrentHashMap<String, Integer> map3;
 
     // Tests new class alone
-    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+    // BUG: Diagnostic contains: ConcurrentHashMap is not well supported on iOS
     map3 = new ConcurrentHashMap<String, Integer>();
 
     // Tests special case - incompatable interface with variable that is instantiated later
@@ -42,20 +42,20 @@ public class UnnecessaryConcurrentHashMapTestPositive {
     ConcurrentMap<Object, String> map4;
 
     // Tests declaration with invalid interface on same line as new class
-    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+    // BUG: Diagnostic contains: ConcurrentHashMap is not well supported on iOS
     ConcurrentMap<String, Integer> map5 = new ConcurrentHashMap<>();
 
     // Tests declaration with valid interface on same line as new class
-    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+    // BUG: Diagnostic contains: ConcurrentHashMap is not well supported on iOS
     Map<String, Integer> map6 = new ConcurrentHashMap<>();
 
     // Tests special case - incompatable interface with variable that is instantiated later
-    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+    // BUG: Diagnostic contains: ConcurrentHashMap is not well supported on iOS
     map4 = new ConcurrentHashMap<>();
 
     if (true) {
       // Tests special case - variable declaration not in same scope
-      // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+      // BUG: Diagnostic contains: ConcurrentHashMap is not well supported on iOS
       map4 = new ConcurrentHashMap<>();
     }
   }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.errorprone.xplat.checker.testdata;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class UnnecessaryConcurrentHashMapTestPositive {
+
+  public void test() {
+    ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<String, Integer>();
+
+    ConcurrentHashMap<String, Integer> map2 = new ConcurrentHashMap<>();
+
+    ConcurrentHashMap<String, Integer> map3;
+
+    map3 = new ConcurrentHashMap<String, Integer>();
+  }
+}

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
@@ -21,16 +21,27 @@ import java.util.concurrent.ConcurrentMap;
 public class UnnecessaryConcurrentHashMapTestPositive {
 
   public void test() {
+    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<String, Integer>();
 
-    ConcurrentHashMap<String, Integer> map2 = new ConcurrentHashMap<>();
+    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+    ConcurrentHashMap<Object, Long> map2 = new ConcurrentHashMap<>();
 
+    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     ConcurrentHashMap<String, Integer> map3;
 
+    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
     map3 = new ConcurrentHashMap<String, Integer>();
 
-    ConcurrentMap<String, Integer> map4 = new ConcurrentHashMap<>();
+    ConcurrentMap<Object, String> map4;
 
-    Map<String, Integer> map5 = new ConcurrentHashMap<>();
+    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+    ConcurrentMap<String, Integer> map5 = new ConcurrentHashMap<>();
+
+    // BUG: Diagnostic contains: ConcurrentHashMap is not advised
+    Map<String, Integer> map6 = new ConcurrentHashMap<>();
+
+    // xBUG: Diagnostic contains: ConcurrentHashMap is not advised
+    map4 = new ConcurrentHashMap<>();
   }
 }

--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/UnnecessaryConcurrentHashMapTestPositive.java
@@ -14,7 +14,9 @@
 
 package com.google.errorprone.xplat.checker.testdata;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class UnnecessaryConcurrentHashMapTestPositive {
 
@@ -26,5 +28,9 @@ public class UnnecessaryConcurrentHashMapTestPositive {
     ConcurrentHashMap<String, Integer> map3;
 
     map3 = new ConcurrentHashMap<String, Integer>();
+
+    ConcurrentMap<String, Integer> map4 = new ConcurrentHashMap<>();
+
+    Map<String, Integer> map5 = new ConcurrentHashMap<>();
   }
 }


### PR DESCRIPTION
A checker that warns against the use of `ConcurrentHashMap` in declarations and instantiations.
A fix is suggested for issues of 3 kinds:

1. Declaration only
2. Declare and assign to a new `ConcurrentHashMap` on the same line
3. Declare and assign to a new `ConcurrentHashMap` on different lines

Issues of type 1 and 2 always have a complete fix suggested.
Issues of type 3 have a fix suggested for the assignment each time, but a fix for the variable declaration will only be given if:
1. The declaration uses `ConcurrentHashMap`
2. The declaration is not `ConcurrentHashMap` but is in the same scope as the assignment.

If one of these conditions are not met, the user will be asked to check the variable declaration manually.