### PR TITLE
Built in annotation suppression and class link fixes in tests

### DIFF
--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/LegacyTimeBan.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/LegacyTimeBan.java
@@ -43,7 +43,8 @@ import com.sun.tools.javac.code.Type;
         "The usage of several legacy time classes are banned from cross platform development due"
             + " to incompatibilities. If one is sure that they must use one of them, the"
             + " @AllowLegacyTime annotation will override the error.",
-    severity = ERROR)
+    severity = ERROR,
+    suppressionAnnotations = AllowLegacyTime.class)
 public class LegacyTimeBan extends BugChecker implements MethodTreeMatcher, VariableTreeMatcher {
 
   private static final ImmutableSet<String> BANNED_CLASSES =
@@ -51,24 +52,18 @@ public class LegacyTimeBan extends BugChecker implements MethodTreeMatcher, Vari
           "java.util.GregorianCalendar", "java.util.TimeZone", "java.util.SimpleTimeZone");
 
   private static final Matcher<MethodTree> METHOD_MATCHER =
-      Matchers.allOf(
-          Matchers.anyOf(
-              BANNED_CLASSES.stream()
-                  .map(
-                      className ->
-                          Matchers.methodReturns(Matchers.isSameType(className)))
-                  .collect(toImmutableList())),
-          Matchers.not(Matchers.hasAnnotation(AllowLegacyTime.class.getCanonicalName()))
-      );
+      Matchers.anyOf(
+          BANNED_CLASSES.stream()
+              .map(
+                  className ->
+                      Matchers.methodReturns(Matchers.isSameType(className)))
+              .collect(toImmutableList()));
 
   private static final Matcher<VariableTree> VAR_MATCHER =
-      Matchers.allOf(
-          Matchers.anyOf(
-              BANNED_CLASSES.stream()
-                  .map(Matchers::isSameType)
-                  .collect(toImmutableList())),
-          Matchers.not(Matchers.hasAnnotation(AllowLegacyTime.class.getCanonicalName()))
-      );
+      Matchers.anyOf(
+          BANNED_CLASSES.stream()
+              .map(Matchers::isSameType)
+              .collect(toImmutableList()));
 
   private Description message(Tree tree, String className) {
     return buildDescription(tree)
@@ -78,7 +73,7 @@ public class LegacyTimeBan extends BugChecker implements MethodTreeMatcher, Vari
                 className))
         .build();
   }
-
+  
 
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeClassBanTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeClassBanTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Unit tests for {@link MyCustomCheck}.
+ * Unit tests for {@link JodaTimeClassBan}.
  */
 @RunWith(JUnit4.class)
 public class JodaTimeClassBanTest {

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeLocalTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Unit tests for {@link MyCustomCheck}.
+ * Unit tests for {@link JodaTimeLocal}.
  */
 @RunWith(JUnit4.class)
 public class JodaTimeLocalTest {

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBanTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/JodaTimeObjectParamBanTest.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Unit tests for {@link MyCustomCheck}.
+ * Unit tests for {@link JodaTimeObjectParamBan}.
  */
 @RunWith(JUnit4.class)
 public class JodaTimeObjectParamBanTest {

--- a/plugin/src/test/java/com/google/errorprone/xplat/checker/LegacyTimeBanTest.java
+++ b/plugin/src/test/java/com/google/errorprone/xplat/checker/LegacyTimeBanTest.java
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Unit tests for {@link MyCustomCheck}.
+ * Unit tests for {@link LegacyTimeBan}.
  */
 @RunWith(JUnit4.class)
 public class LegacyTimeBanTest {


### PR DESCRIPTION
Changes LegacyTimeBan to use the built in BugChecker suppressionAnnotations rather than my custom solution. 
Additionally, fixes links to classes inside several test files. 