### PR TITLE
Make sure JodaTimeLocal returns early if a tree yields no receiver.

### DIFF
--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/J2objcMethodName.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/J2objcMethodName.java
@@ -348,6 +348,10 @@ public class J2objcMethodName extends BugChecker implements MethodTreeMatcher,
     }
   }
 
+  public J2objcMethodName() {
+    this(ErrorProneFlags.empty());
+  }
+
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
     if (MATCHER.matches(tree, state)) {

--- a/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeLocal.java
+++ b/plugin/src/main/java/com/google/errorprone/xplat/checker/JodaTimeLocal.java
@@ -123,6 +123,10 @@ public class JodaTimeLocal extends BugChecker implements MethodInvocationTreeMat
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     ExpressionTree recv = ASTHelpers.getReceiver(tree);
+    if (recv == null) {
+      return Description.NO_MATCH;
+    }
+
     String recvSrc = state.getSourceForNode(recv);
     Symbol symbol = ASTHelpers.getSymbol(tree);
     List<? extends ExpressionTree> arguments = tree.getArguments();


### PR DESCRIPTION
Also add default constructors to J2objcMethodName and XplatBans.

Make XplatBans load the default configuration file via a resource URL.
