### PR TITLE
Lazy Init Checker - Added missing error check and cleaned up code a bit

### DIFF
--- a/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/LazyInitBanPositiveCases.java
+++ b/plugin/src/test/resources/com/google/errorprone/xplat/checker/testdata/LazyInitBanPositiveCases.java
@@ -100,4 +100,12 @@ public class LazyInitBanPositiveCases {
     return y;
   }
 
+  // BUG: Diagnostic contains: Please synchronize this method.
+  public String lazyInit9() {
+    if (z == null) {
+      z = new String();
+    }
+    return z;
+  }
+
 }


### PR DESCRIPTION
I realized when making my intern presentation that I forgot to make a separate error for a missing synchronization on an otherwise correct method. This fixes that issue by adding a new test and new error, and changes the code to better handle new error types in the future in the process.